### PR TITLE
[JENKINS-16957] Tracker field validations not working in CollabNet plugin

### DIFF
--- a/src/main/java/hudson/plugins/collabnet/tracker/CNTracker.java
+++ b/src/main/java/hudson/plugins/collabnet/tracker/CNTracker.java
@@ -593,20 +593,18 @@ public class CNTracker extends AbstractTeamForgeNotifier {
 
         /**
          * Form validation for the tracker field.
-         *
-         * @param req StaplerRequest which contains parameters from the config.jelly.
          */
-        public FormValidation doCheckTracker(StaplerRequest req) throws RemoteException {
-            return CNFormFieldValidator.trackerCheck(req);
+        public FormValidation doCheckTracker(CollabNetApp cna, 
+                @QueryParameter String project, @QueryParameter String tracker) throws RemoteException {
+            return CNFormFieldValidator.trackerCheck(cna, project, tracker);
         }
         
         /**
          * Form validation for "assign issue to".
-         *
-         * @param req StaplerRequest which contains parameters from the config.jelly.
          */
-        public FormValidation doCheckAssign(StaplerRequest req) throws RemoteException {
-            return CNFormFieldValidator.assignCheck(req);
+        public FormValidation doCheckAssignUser(CollabNetApp cna, 
+                @QueryParameter String project, @QueryParameter String assignUser) throws RemoteException {
+            return CNFormFieldValidator.assignCheck(cna, project, assignUser);
         }
         
         /**

--- a/src/main/java/hudson/plugins/collabnet/util/CNFormFieldValidator.java
+++ b/src/main/java/hudson/plugins/collabnet/util/CNFormFieldValidator.java
@@ -342,13 +342,10 @@ public abstract class CNFormFieldValidator {
      * Class to check that a tracker exists.  Expects a StaplerRequest with 
      * a url, username, password, project, and tracker.
      */
-    public static FormValidation trackerCheck(StaplerRequest request) throws RemoteException {
-        String tracker = request.getParameter("tracker");
-        String project = request.getParameter("project");
+    public static FormValidation trackerCheck(CollabNetApp cna, String project, String tracker) throws RemoteException {
         if (CommonUtil.unset(tracker)) {
             return FormValidation.error("The tracker is required.");
         }
-        CollabNetApp cna = CNHudsonUtil.getCollabNetApp(request);
         try {
             if (cna == null) {
                 return FormValidation.ok();
@@ -372,19 +369,16 @@ public abstract class CNFormFieldValidator {
      * Expects a StaplerRequest with login info (url, username, password), 
      * project, and assign (which is the username).
      */
-    public static FormValidation assignCheck(StaplerRequest request) throws RemoteException {
-        String assign = StringUtils.strip(request.getParameter("assign"));
+    public static FormValidation assignCheck(CollabNetApp cna, String project, String assign) throws RemoteException {
+        assign = StringUtils.strip(assign);
         if (CommonUtil.unset(assign)) {
             return FormValidation.ok();
         }
-        String project = request.getParameter("project");
-
-        CollabNetApp cna = CNHudsonUtil.getCollabNetApp(request);
         try {
             if (cna == null) {
                 return FormValidation.ok();
             }
-            CTFProject p = cna.getProjectById(project);
+            CTFProject p = cna.getProjectByTitle(project);
             if (p == null) {
                 return FormValidation.ok();
             }


### PR DESCRIPTION
- src/main/java/hudson/plugins/collabnet/tracker/CNTracker.java
  (doCheckTracker): Use updated argument list style
  (doCheckAssign): Use updated argument list style and change to doCheckAssignUser to match the
  field name.
- src/main/java/hudson/plugins/collabnet/util/CNFormFieldValidator.java
  (trackerCheck, assignCheck): reflect changes above. And for assignCheck fix the project
  lookup to be by the project name/title.
