### PR TITLE
Adds possibility to create new release for a package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.596.2</version>
+    <version>1.399</version>
   </parent>
   <artifactId>collabnet</artifactId>
   <version>1.1.10-SNAPSHOT</version>
@@ -74,9 +74,9 @@
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
+      <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>2.17</version>
+      <version>1.11</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version>
+    <version>1.596.2</version>
   </parent>
   <artifactId>collabnet</artifactId>
   <version>1.1.10-SNAPSHOT</version>
@@ -74,9 +74,9 @@
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.hudson.plugins</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>1.11</version>
+      <version>2.17</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>

--- a/src/main/java/hudson/plugins/collabnet/FakeChangeLogSCM.java
+++ b/src/main/java/hudson/plugins/collabnet/FakeChangeLogSCM.java
@@ -6,12 +6,15 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.User;
 import hudson.scm.ChangeLogParser;
+import hudson.scm.RepositoryBrowser;
 import hudson.scm.ChangeLogSet;
+import hudson.scm.SCMDescriptor;
 import hudson.scm.ChangeLogSet.Entry;
 import hudson.scm.NullSCM;
 import hudson.scm.SCM;
 import hudson.util.AdaptedIterator;
 import hudson.util.IOException2;
+
 import org.xml.sax.SAXException;
 
 import java.io.File;
@@ -21,11 +24,13 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import jenkins.model.Jenkins;
 import static java.util.Arrays.asList;
 
 /**
@@ -78,6 +83,15 @@ public class FakeChangeLogSCM extends NullSCM {
         oos.close();
         commits.clear();
         return true;
+    }
+
+    @Override
+    public RepositoryBrowser<?> getBrowser() {
+        return new RepositoryBrowser<ChangeLogSet.Entry>() {
+            @Override public URL getChangeSetLink(ChangeLogSet.Entry changeSet) throws IOException {
+                return null;
+            }
+        };
     }
 
     @Override

--- a/src/main/java/hudson/plugins/collabnet/auth/CNAuthorizationStrategy.java
+++ b/src/main/java/hudson/plugins/collabnet/auth/CNAuthorizationStrategy.java
@@ -1,6 +1,7 @@
 package hudson.plugins.collabnet.auth;
 
 import com.collabnet.ce.webservices.CollabNetApp;
+
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractItem;
@@ -16,6 +17,7 @@ import hudson.security.AuthorizationStrategy;
 import hudson.util.FormValidation;
 import hudson.util.VersionNumber;
 import net.sf.json.JSONObject;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -38,6 +40,58 @@ import static java.lang.Math.max;
  * Class for the CollabNet Authorization.
  */
 public class CNAuthorizationStrategy extends AuthorizationStrategy {
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((adminGroups == null) ? 0 : adminGroups.hashCode());
+        result = prime * result + ((adminUsers == null) ? 0 : adminUsers.hashCode());
+        result = prime * result + mAuthCacheTimeoutMin;
+        result = prime * result + ((readGroups == null) ? 0 : readGroups.hashCode());
+        result = prime * result + ((readUsers == null) ? 0 : readUsers.hashCode());
+        result = prime * result + ((rootACL == null) ? 0 : rootACL.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CNAuthorizationStrategy other = (CNAuthorizationStrategy) obj;
+        if (adminGroups == null) {
+            if (other.adminGroups != null)
+                return false;
+        } else if (!adminGroups.equals(other.adminGroups))
+            return false;
+        if (adminUsers == null) {
+            if (other.adminUsers != null)
+                return false;
+        } else if (!adminUsers.equals(other.adminUsers))
+            return false;
+        if (mAuthCacheTimeoutMin != other.mAuthCacheTimeoutMin)
+            return false;
+        if (readGroups == null) {
+            if (other.readGroups != null)
+                return false;
+        } else if (!readGroups.equals(other.readGroups))
+            return false;
+        if (readUsers == null) {
+            if (other.readUsers != null)
+                return false;
+        } else if (!readUsers.equals(other.readUsers))
+            return false;
+        if (rootACL == null) {
+            if (other.rootACL != null)
+                return false;
+        } else if (!rootACL.equals(other.rootACL))
+            return false;
+        return true;
+    }
+
     private Collection<String> readUsers;
     private Collection<String> readGroups;
     private Collection<String> adminUsers;

--- a/src/main/java/hudson/plugins/collabnet/documentuploader/CNDocumentUploader.java
+++ b/src/main/java/hudson/plugins/collabnet/documentuploader/CNDocumentUploader.java
@@ -21,6 +21,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.util.FormValidation;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.jenkinsci.remoting.RoleChecker;
 
 import javax.activation.MimetypesFileTypeMap;
 import java.io.File;
@@ -380,6 +381,10 @@ public class CNDocumentUploader extends AbstractTeamForgeNotifier {
                         return "text/plain";
                     }
                     return new MimetypesFileTypeMap().getContentType(f);
+                }
+                @Override
+                public void checkRoles(RoleChecker arg0) throws SecurityException {
+                    // TODO Auto-generated method stub
                 }});
         } catch (IOException ioe) { // ignore exceptions
         } catch (InterruptedException ie) {}
@@ -471,6 +476,10 @@ public class CNDocumentUploader extends AbstractTeamForgeNotifier {
         public String invoke(File f, VirtualChannel channel) throws IOException {
             CollabNetApp cnApp = CNHudsonUtil.recreateCollabNetApp(mUrl, mUsername, mSessionId);
             return cnApp.upload(f).getId();
+        }
+        @Override
+        public void checkRoles(RoleChecker arg0) throws SecurityException {
+            // TODO Auto-generated method stub
         }
     }
 

--- a/src/main/java/hudson/plugins/collabnet/documentuploader/CNDocumentUploader.java
+++ b/src/main/java/hudson/plugins/collabnet/documentuploader/CNDocumentUploader.java
@@ -21,7 +21,6 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.util.FormValidation;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.jenkinsci.remoting.RoleChecker;
 
 import javax.activation.MimetypesFileTypeMap;
 import java.io.File;
@@ -381,10 +380,6 @@ public class CNDocumentUploader extends AbstractTeamForgeNotifier {
                         return "text/plain";
                     }
                     return new MimetypesFileTypeMap().getContentType(f);
-                }
-                @Override
-                public void checkRoles(RoleChecker arg0) throws SecurityException {
-                    // TODO Auto-generated method stub
                 }});
         } catch (IOException ioe) { // ignore exceptions
         } catch (InterruptedException ie) {}
@@ -476,10 +471,6 @@ public class CNDocumentUploader extends AbstractTeamForgeNotifier {
         public String invoke(File f, VirtualChannel channel) throws IOException {
             CollabNetApp cnApp = CNHudsonUtil.recreateCollabNetApp(mUrl, mUsername, mSessionId);
             return cnApp.upload(f).getId();
-        }
-        @Override
-        public void checkRoles(RoleChecker arg0) throws SecurityException {
-            // TODO Auto-generated method stub
         }
     }
 

--- a/src/main/java/hudson/plugins/collabnet/filerelease/CNFileRelease.java
+++ b/src/main/java/hudson/plugins/collabnet/filerelease/CNFileRelease.java
@@ -26,6 +26,7 @@ import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.jenkinsci.remoting.RoleChecker;
 
 import javax.activation.MimetypesFileTypeMap;
 import java.io.File;
@@ -312,6 +313,10 @@ public class CNFileRelease extends AbstractTeamForgeNotifier {
         public String invoke(File f, VirtualChannel channel) throws IOException {
             CollabNetApp cnApp = CNHudsonUtil.recreateCollabNetApp(mServerUrl, mUsername, mSessionId);
             return cnApp.upload(f).getId();
+        }
+        @Override
+        public void checkRoles(RoleChecker arg0) throws SecurityException {
+            // TODO Auto-generated method stub
         }
     }
 

--- a/src/main/java/hudson/plugins/collabnet/filerelease/CNFileRelease.java
+++ b/src/main/java/hudson/plugins/collabnet/filerelease/CNFileRelease.java
@@ -26,7 +26,6 @@ import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.jenkinsci.remoting.RoleChecker;
 
 import javax.activation.MimetypesFileTypeMap;
 import java.io.File;
@@ -313,10 +312,6 @@ public class CNFileRelease extends AbstractTeamForgeNotifier {
         public String invoke(File f, VirtualChannel channel) throws IOException {
             CollabNetApp cnApp = CNHudsonUtil.recreateCollabNetApp(mServerUrl, mUsername, mSessionId);
             return cnApp.upload(f).getId();
-        }
-        @Override
-        public void checkRoles(RoleChecker arg0) throws SecurityException {
-            // TODO Auto-generated method stub
         }
     }
 

--- a/src/main/java/hudson/plugins/collabnet/filerelease/CNFileRelease.java
+++ b/src/main/java/hudson/plugins/collabnet/filerelease/CNFileRelease.java
@@ -26,6 +26,7 @@ import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.jenkinsci.remoting.RoleChecker;
 
 import javax.activation.MimetypesFileTypeMap;
 import java.io.File;
@@ -53,6 +54,10 @@ public class CNFileRelease extends AbstractTeamForgeNotifier {
     private boolean overwrite;
     private FilePattern[] file_patterns;
 
+    private String description = "";
+    private static final String RELEASE_STATUS_ACTIVE = "active";
+    private static final String MATURITY_NONE = "";
+    
     /**
      * Creates a new CNFileRelease object.
      *
@@ -309,6 +314,10 @@ public class CNFileRelease extends AbstractTeamForgeNotifier {
             CollabNetApp cnApp = CNHudsonUtil.recreateCollabNetApp(mServerUrl, mUsername, mSessionId);
             return cnApp.upload(f).getId();
         }
+        @Override
+        public void checkRoles(RoleChecker arg0) throws SecurityException {
+            // TODO Auto-generated method stub
+        }
     }
 
     /**
@@ -388,10 +397,11 @@ public class CNFileRelease extends AbstractTeamForgeNotifier {
         }
         CTFRelease release = pkg.getReleaseByTitle(getRelease());
         if (release == null) {
-            this.logConsole("Critical Error: releaseId cannot be found for " +
+            release = pkg.createRelease(getRelease(), description, RELEASE_STATUS_ACTIVE, MATURITY_NONE);
+            this.logConsole("Note: releaseId cannot be found for " +
                      this.getRelease() + ".  " +
-                     "Setting build status to UNSTABLE (or worse).");
-            return null;
+                     "Creating a new release with specified releaseId. Setting build status to STABLE.");
+            return release;
         }
         return release;
     }

--- a/src/main/java/hudson/plugins/collabnet/pblupload/PblUploader.java
+++ b/src/main/java/hudson/plugins/collabnet/pblupload/PblUploader.java
@@ -18,7 +18,6 @@ import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.File;
 import java.io.IOException;
@@ -623,10 +622,6 @@ public class PblUploader extends Notifier implements java.io.Serializable {
                                                 args, 
                                                 file,
                                                 true);
-            }
-            @Override
-            public void checkRoles(RoleChecker arg0) throws SecurityException {
-                // TODO Auto-generated method stub
             }
         });
         logPblCallResults(result, args, uploadFilePath, workspace);

--- a/src/main/java/hudson/plugins/collabnet/pblupload/PblUploader.java
+++ b/src/main/java/hudson/plugins/collabnet/pblupload/PblUploader.java
@@ -18,6 +18,7 @@ import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.File;
 import java.io.IOException;
@@ -622,6 +623,10 @@ public class PblUploader extends Notifier implements java.io.Serializable {
                                                 args, 
                                                 file,
                                                 true);
+            }
+            @Override
+            public void checkRoles(RoleChecker arg0) throws SecurityException {
+                // TODO Auto-generated method stub
             }
         });
         logPblCallResults(result, args, uploadFilePath, workspace);

--- a/src/main/java/hudson/plugins/collabnet/util/CNFormFieldValidator.java
+++ b/src/main/java/hudson/plugins/collabnet/util/CNFormFieldValidator.java
@@ -295,14 +295,14 @@ public abstract class CNFormFieldValidator {
             if (pkg != null) {
                 CTFRelease r = pkg.getReleaseByTitle(release);
                 if (r == null)
-                    return FormValidation.warning("Release could not be found.");
+                    return FormValidation.warning("Release could not be found. Do you want to make a new release?");
             } else {
                 // locate the release from all the packages
                 for (CTFPackage x : p.getPackages()) {
                     if (x.getReleaseByTitle(release)!=null)
                         return FormValidation.ok();
                 }
-                return FormValidation.warning("Release could not be found.");
+                return FormValidation.warning("Release could not be found. Do you want to make a new release?");
             }
             return FormValidation.ok();
         } finally {

--- a/src/test/java/hudson/plugins/collabnet/auth/AuthzTest.java
+++ b/src/test/java/hudson/plugins/collabnet/auth/AuthzTest.java
@@ -1,13 +1,7 @@
 package hudson.plugins.collabnet.auth;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.plugins.collabnet.util.Util;
-import hudson.security.ACL;
 import hudson.security.AuthorizationStrategy;
-import hudson.security.LegacyAuthorizationStrategy;
-import hudson.security.SparseACL;
 
 /**
  * Base class for test cases.
@@ -22,37 +16,15 @@ public class AuthzTest extends AbstractSecurityTestCase {
      * Verifies that the UI is bound correctly to properties
      */
     public void testConfigRoundtrip() throws Exception {
-        hudson.setAuthorizationStrategy(new LegacyAuthorizationStrategy());
-        roundtripAndAssert(new CNAuthorizationStrategy("foo,bar","dev,op","alice,boss,root","god,budda",35) {
-            /**
-             * Allow resubmission of the system config without logging in first.
-             * @return
-             */
-            @Override
-            public ACL getRootACL() {
-                SparseACL acl = new SparseACL(null);
-                acl.add(ACL.ANONYMOUS, Hudson.ADMINISTER, true);
-                return acl;
-            }
-
-            @Override
-            public Descriptor<AuthorizationStrategy> getDescriptor() {
-                return Hudson.getInstance().getDescriptorOrDie(CNAuthorizationStrategy.class);
-            }
-        });
-
+        hudson.setAuthorizationStrategy(new AuthorizationStrategy.Unsecured());
+        submit(createWebClient().goTo("configure").getFormByName("config"));
+        roundtripAndAssert(new MockCNAuthorizationStrategy("foo,bar","dev,op","alice,boss,root","god,budda",35));
     }
 
     private void roundtripAndAssert(CNAuthorizationStrategy original) throws Exception {
         hudson.setAuthorizationStrategy(original);
-        try {
-            submit(createWebClient().goTo("configure").getFormByName("config"));
-            fail(); // submission would succeed but the rendering of the top page would fail, so this should result in an error
-        } catch (FailingHttpStatusCodeException e) {
-            // if the submission succeeds, we should see a new instance
-            assertNotSame(original,hudson.getAuthorizationStrategy());
-            assertEqualBeans(original, hudson.getAuthorizationStrategy(), FIELDS);
-        }
+        submit(createWebClient().goTo("configure").getFormByName("config"));
+        assertEqualBeans(original, hudson.getAuthorizationStrategy(), FIELDS);
     }
 
     /**

--- a/src/test/java/hudson/plugins/collabnet/auth/MockCNAuthorizationStrategy.java
+++ b/src/test/java/hudson/plugins/collabnet/auth/MockCNAuthorizationStrategy.java
@@ -1,0 +1,39 @@
+package hudson.plugins.collabnet.auth;
+
+import hudson.model.Descriptor;
+import hudson.model.Hudson;
+import hudson.security.ACL;
+import hudson.security.AuthorizationStrategy;
+import hudson.security.SparseACL;
+
+import java.util.List;
+
+public class MockCNAuthorizationStrategy extends CNAuthorizationStrategy {
+
+    public MockCNAuthorizationStrategy(List<String> readUsers, List<String> readGroups,
+            List<String> adminUsers, List<String> adminGroups, int permCacheTimeoutMin) {
+        super(readUsers, readGroups, adminUsers, adminGroups, permCacheTimeoutMin);
+    }
+
+    public MockCNAuthorizationStrategy(String readUsers, String readGroups, String adminUsers,
+            String adminGroups, int permCacheTimeoutMin) {
+        super(readUsers, readGroups, adminUsers, adminGroups, permCacheTimeoutMin);
+    }
+
+    /**
+     * Allow resubmission of the system config without logging in first.
+     * @return
+     */
+    @Override
+    public ACL getRootACL() {
+        SparseACL acl = new SparseACL(null);
+        acl.add(ACL.ANONYMOUS, Hudson.ADMINISTER, true);
+        return acl;
+    }
+
+    @Override
+    public Descriptor<AuthorizationStrategy> getDescriptor() {
+        return Hudson.getInstance().getDescriptorOrDie(CNAuthorizationStrategy.class);
+    }
+
+}

--- a/src/test/java/hudson/plugins/collabnet/util/Util.java
+++ b/src/test/java/hudson/plugins/collabnet/util/Util.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
+import org.jenkinsci.remoting.RoleChecker;
 import org.jvnet.hudson.test.HudsonTestCase.WebClient;
 
 /**
@@ -261,6 +262,10 @@ public class Util {
                 fw.write(fileContent);
                 fw.close();
                 return null;
+            }
+            @Override
+            public void checkRoles(RoleChecker arg0) throws SecurityException {
+                // TODO Auto-generated method stub
             }
         });
     }

--- a/src/test/java/hudson/plugins/collabnet/util/Util.java
+++ b/src/test/java/hudson/plugins/collabnet/util/Util.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import org.jenkinsci.remoting.RoleChecker;
 import org.jvnet.hudson.test.HudsonTestCase.WebClient;
 
 /**
@@ -262,10 +261,6 @@ public class Util {
                 fw.write(fileContent);
                 fw.close();
                 return null;
-            }
-            @Override
-            public void checkRoles(RoleChecker arg0) throws SecurityException {
-                // TODO Auto-generated method stub
             }
         });
     }


### PR DESCRIPTION
This fix has been created with the objective of improving the existing teamforge-collabnet “File Release” plugin, which is missing a critical component necessary to fulfill our requirements. Currently, the plugin serves to upload jar to an existing File release in teamforge Project. Our requirements is that new File Release should be created from the plugin.

We have created a JIRA-issue with issue number JENKINS-29314 (https://issues.jenkins-ci.org/browse/JENKINS-29314?filter=-1)
