### PR TITLE
Change icons for Document/FRS/PBL uploader

### DIFF
--- a/src/main/java/hudson/plugins/collabnet/documentuploader/CNDocumentUploader.java
+++ b/src/main/java/hudson/plugins/collabnet/documentuploader/CNDocumentUploader.java
@@ -220,7 +220,7 @@ public class CNDocumentUploader extends AbstractTeamForgeNotifier {
     private Action createAction(int numUploaded, CTFDocumentFolder folder) {
         String displaymsg = "Download from CollabNet Documents";
         return new CnduResultAction(displaymsg, 
-                                    IMAGE_URL + "cn-icon.gif", 
+                                    IMAGE_URL + "cloud.png", 
                                     "console",
                                     folder.getURL(),
                                     numUploaded);

--- a/src/main/java/hudson/plugins/collabnet/filerelease/CNFileRelease.java
+++ b/src/main/java/hudson/plugins/collabnet/filerelease/CNFileRelease.java
@@ -194,7 +194,7 @@ public class CNFileRelease extends AbstractTeamForgeNotifier {
     public CnfrResultAction createAction(int numUploaded, CTFRelease release) {
         String displaymsg = "Download from CollabNet File Release System";
         return new CnfrResultAction(displaymsg,
-                                    IMAGE_URL + "cn-icon.gif", 
+                                    IMAGE_URL + "cloud.png", 
                                     "console",
                                     release.getUrl(),
                                     numUploaded);

--- a/src/main/java/hudson/plugins/collabnet/pblupload/PblUploader.java
+++ b/src/main/java/hudson/plugins/collabnet/pblupload/PblUploader.java
@@ -280,7 +280,7 @@ public class PblUploader extends Notifier implements java.io.Serializable {
         build.
             addAction(new 
                       PblUploadResultAction(LEFT_NAV_DISPLAY_MESSAGE, 
-                                            IMAGE_URL + "cubit-icon.gif", 
+                                            IMAGE_URL + "cloud.png", 
                                             "console", 
                                             addTrailSlash(this.
                                                           getRemoteURL(build)),


### PR DESCRIPTION
Replace icons for Document/FRS/PBL uploader with latest new icons. For
now, replacing it with cloud-icon. will replace it again once get the
new icons from UX/UI team.