### PR TITLE
[artf277580] - merge ActionHub code into EventQ / CollabNet plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>3.6.1</version>
+      <version>3.6.5</version>
     </dependency>
     <dependency>
          <groupId>org.easymock</groupId>
@@ -182,6 +182,32 @@
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
       <version>2.5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.6.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.6.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.6.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.16.10</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/plugins/collabnet/actionhub/ActionHubPlugin.java
+++ b/src/main/java/hudson/plugins/collabnet/actionhub/ActionHubPlugin.java
@@ -1,0 +1,447 @@
+package hudson.plugins.collabnet.actionhub;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import hudson.Extension;
+import hudson.plugins.collabnet.share.TeamForgeShare;
+import hudson.util.FormValidation;
+import hudson.model.*;
+import hudson.security.*;
+import hudson.tasks.Builder;
+import hudson.tasks.BuildStepDescriptor;
+import net.sf.json.JSONObject;
+import jenkins.model.*;
+
+import org.acegisecurity.Authentication;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.tools.json.JSONReader;
+
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import lombok.extern.java.Log;
+
+/**
+ * This plugin listens on Rabbit queues for messages from ActionHub.
+ * It reads two types of messages- (1) get actions requests and (2) trigger build requests. 
+ *
+ * @author Neel Shah
+ */
+@Log
+public class ActionHubPlugin extends Builder {
+
+    static Channel channel = null;
+    static Connection connection = null;
+    static Consumer workflowMsgConsumer = null;
+    static Consumer actionsMsgConsumer = null;
+    static MQConnectionHandler shutDownListener = null;
+    private final static Jenkins jenkins = Jenkins.getInstance();
+    
+    
+    // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
+    @DataBoundConstructor
+    public ActionHubPlugin() {
+        super();
+    }
+
+    // This method is called after Jenkins is initialized and all jobs have been loaded
+    // In case of an initial plugin install, it will be called right after install is completed.
+    @Initializer(after=InitMilestone.JOB_LOADED)
+    public static void init()  {
+        boolean reConnectSuccess = true;
+        int tries = 0;
+
+        do {
+
+            try {
+                TimeUnit.SECONDS.sleep(1);
+            } catch (InterruptedException ie) {
+                ie.printStackTrace();
+            }
+
+            log.info("Now going to try to connect to Rabbit.");
+            reConnectSuccess = true; //assume retry succeeded
+
+            try {
+                connectAndListen();
+            } catch (IOException ioe) {
+                reConnectSuccess = false;
+            } catch (TimeoutException te) {
+                reConnectSuccess = false;
+            }
+
+            tries++;
+        } while (!reConnectSuccess && tries < 5);
+
+        if (!reConnectSuccess) {
+            log.info("Unable to connect to Rabbit. Giving up. Check if Rabbit instance is up, then restart Jenkins.");
+        }
+    }
+
+
+    public static void connectAndListen() throws IOException, TimeoutException {
+        if (connection != null && connection.isOpen()) {
+            if (connection.getClientProvidedName() == Constants.RABBIT_CONNECTION_NAME) {
+                log.info("Closing the connection");
+                connection.removeShutdownListener(shutDownListener);
+                connection.close();
+            }
+        }
+
+        TeamForgeShare.TeamForgeShareDescriptor descriptor = TeamForgeShare.getTeamForgeShareDescriptor();
+        if (descriptor.areActionHubSettingsValid() == true) {
+            ConnectionFactory factory = new ConnectionFactory();
+            factory.setHost(descriptor.getActionHubMqHost());
+            factory.setPort(descriptor.getActionHubMqPort());
+            factory.setUsername(descriptor.getActionHubMqUsername());
+            factory.setPassword(descriptor.getActionHubMqPassword());
+            connection = factory.newConnection(Constants.RABBIT_CONNECTION_NAME);
+            shutDownListener = new MQConnectionHandler();
+            connection.addShutdownListener(shutDownListener);
+            channel = connection.createChannel();
+            log.info("Opening a new connection with " + descriptor.getActionHubMqHost() + ":" + descriptor.getActionHubMqPort() + " on exchange " + descriptor.getActionHubMqExchange() + ". Actions Routing key is " + descriptor.getActionHubMqActionsQueue() + ". Workflow Routing key is " + descriptor.getActionHubMqWorkflowQueue());
+
+            initWorkflowQueueListener(descriptor.getActionHubMqExchange(), descriptor.getActionHubMqWorkflowQueue());
+            initActionsQueueListener(descriptor.getActionHubMqExchange(), descriptor.getActionHubMqActionsQueue());
+        } else {
+            log.info("Error: Unable to listen on queue. Check ActionHub connection settings.");
+        }
+
+    }
+
+    public static void initWorkflowQueueListener(String exchange, String routingKey) throws IOException  {
+        channel.exchangeDeclare(exchange, Constants.RABBIT_EXCHANGE_TYPE, true, false, false, null);
+        String queueName = channel.queueDeclare().getQueue();
+        channel.queueBind(queueName, exchange, routingKey);
+
+        // The Consumer will Listen for messages
+        workflowMsgConsumer = new DefaultConsumer(channel) {
+            @Override
+            public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)     {
+                String message = "";
+                try {
+                    message = new String(body, Constants.CONTENT_TYPE_UTF_8);
+                    log.info("Received : " + message + " on " + envelope.getRoutingKey());
+                } catch (IOException e) {
+                    log.info("Could not read workflow message from queue: " + e.getMessage());
+                }
+
+                // Parse the received message
+                JSONReader jsonParser = new JSONReader();
+                Map<String, Object> request = (Map<String, Object>) jsonParser.read(message);
+                String passedInWorkFlowId = (String) request.get(Constants.REQUEST_JSON_WORKFLOW_ID);
+                        
+                if (jenkins != null) {
+                    authenticate();
+
+                    // Get the list of buildable items. This includes projects, pipelines, etc.
+                    List<BuildableItem> buildableItemList = jenkins.getAllItems(BuildableItem.class);
+                    boolean found = false;
+
+                    if (buildableItemList != null) {
+
+                        // Go through the list and see if the passedInWorkFlowId is a buildable item
+                        for (BuildableItem buildItem : buildableItemList) {
+                            if (buildItem.getFullName().equals(passedInWorkFlowId)) {
+                                found = true;
+                                boolean buildKickoff = false;
+                                HashMap<String, String> ruleInformation = (HashMap) request.get(Constants.REQUEST_JSON_RULE_INFO);
+                                String ruleName = ruleInformation.get(Constants.REQUEST_JSON_RULE_INFO_NAME);
+                                String userName = ruleInformation.get(Constants.REQUEST_JSON_USER_NAME);
+                                Cause cause = new BuildCause(envelope.getRoutingKey(), ruleName, userName);
+
+                                if (buildItem instanceof AbstractProject) {
+                                    // This is a regular project. Can pass params.
+                                    List<HashMap> passedInParameters = (ArrayList<HashMap>) request.get(Constants.REQUEST_JSON_WORKFLOW_ARGUMENTS);
+                                    List<ParameterValue> parameters = new ArrayList<ParameterValue>();
+
+                                    if (passedInParameters != null) {
+                                        for (HashMap passedInParameter : passedInParameters) {
+                                            String name = (String) passedInParameter.get(Constants.REQUEST_JSON_WORKFLOW_ARGUMENTS_NAME);
+                                            String value = (String) passedInParameter.get(Constants.REQUEST_JSON_WORKFLOW_ARGUMENTS_VALUE);
+                                            parameters.add(new StringParameterValue(name, value));
+                                        }
+                                    }
+                                    
+                                    AbstractProject project = (AbstractProject)buildItem;
+                                    ParametersAction paramAction = new ParametersAction(parameters);
+                                    buildKickoff = project.scheduleBuild(0, cause, paramAction);
+                                    //Schedule a build, and return a Future object to wait for the completion of the build.
+                                    //Works only with objects of type AbstractProject, not with BuildableItem.
+                                    //We can use this to pass status message back to rabbitMQ
+                                    //QueueTaskFuture<AbstractBuild> statusListener = p.scheduleBuild2(0);
+                                    //AbstractBuild buildInfo = statusListener.get();
+                                    //Result result = buildInfo.getResult();
+                                    //LOG.info("Result: " + result.toString());
+                                } else {
+                                    // This is a buildable item but not a regular project. Cannot pass params.
+                                    buildKickoff = buildItem.scheduleBuild(0, cause);
+                                }
+    
+                                if (buildKickoff == true) {
+                                    log.info("Now building: " + buildItem.getFullName());
+                                }
+    
+                                break;
+                            } 
+                        }
+                        
+                        if (!found) {
+                            log.info("Could not find that Project.");
+                        } 
+                    } else {
+                        log.info("The list was null. No buildable items found.");
+                    }
+                } else {
+                    log.info("Error: Jenkins was null.");
+                }
+            }
+        };
+        
+        channel.basicConsume(queueName, true, workflowMsgConsumer);
+        log.info("Waiting for workflow messages ...");
+    }    
+
+
+    public static void initActionsQueueListener(String exchange, String routingKey) throws IOException {
+        Map<String, Object> args = new HashMap<String, Object>();
+        args.put(Constants.RABBIT_TIME_TO_LIVE_KEY, Constants.RABBIT_TIME_TO_LIVE_VALUE);
+        channel.exchangeDeclare(exchange, Constants.RABBIT_EXCHANGE_TYPE, true, false, false, args);
+        String queueName = channel.queueDeclare().getQueue();
+        channel.queueBind(queueName, exchange, routingKey);
+        
+        // The Consumer will Listen for messages
+        actionsMsgConsumer = new DefaultConsumer(channel) {
+            @Override
+            public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) {
+                String message = "";
+                try {
+                    message = new String(body, Constants.CONTENT_TYPE_UTF_8);
+                    log.info("Received : " + message + " on " + envelope.getRoutingKey());
+                } catch (IOException e) {
+                    log.info("Could not read action request from queue: " + e.getMessage());
+                }
+
+
+                // Parse the received message
+                JSONReader jsonParser = new JSONReader();
+                Map<String, Object> request = (Map<String, Object>) jsonParser.read(message);
+                String messageType = (String) request.get("messageType");
+                log.info("messageType : " + messageType);
+
+                Set<Job> itemList = prepareJobList(messageType);
+
+                List<Workflow> workflows = new ArrayList<Workflow>();
+
+                for (Job item : itemList) {
+                    String buildId = item.getFullName();
+                    String buildName = item.getName();
+                    String buildDescription = null;
+
+                    Map<String, WorkflowParameter> buildParametersMap = new HashMap<String, WorkflowParameter>();
+
+
+                    if (item instanceof AbstractProject) {
+
+                        // this is a regular project.
+                        AbstractProject project = (AbstractProject) item;
+                        buildDescription = project.getDescription();
+
+                        List<Action> actions = project.getActions();
+                        for (Action action : actions) {
+                            if (action instanceof ParametersDefinitionProperty) {
+                                ParametersDefinitionProperty definitions = (ParametersDefinitionProperty) action;
+
+                                List<ParameterDefinition> parameters = definitions.getParameterDefinitions();
+
+                                for (ParameterDefinition parameter : parameters) {
+                                    String paramName = parameter.getName();
+                                    String paramDescription = parameter.getDescription();
+                                    String paramType = "";
+                                    String[] paramChoices = new String[0];
+                                    if (parameter instanceof StringParameterDefinition) {
+                                        paramType = Constants.ParamDataTypes.STRING;
+                                    } else if (parameter instanceof ChoiceParameterDefinition) {
+                                        paramType = Constants.ParamDataTypes.ENUM;
+                                        List<String> choiceList = ((ChoiceParameterDefinition) parameter).getChoices();
+                                        paramChoices = choiceList.toArray(new String[choiceList.size()]);
+                                    }
+
+                                    String paramDefaultValue = "";
+
+                                    ParameterValue defaultVal = parameter.getDefaultParameterValue();
+                                    if (defaultVal != null) {
+                                        Object defaultValObj = defaultVal.getValue();
+                                        if (defaultValObj != null) {
+                                            paramDefaultValue = defaultValObj.toString();
+                                        }
+                                    }
+
+                                    WorkflowParameter paramAttributes = new WorkflowParameter(paramDescription, paramType, paramDefaultValue, paramChoices);
+                                    buildParametersMap.put(paramName, paramAttributes);
+                                }
+                            }
+                        }
+
+                    } else {
+                        // This is merely a buildable item.
+                        buildDescription = item.getDisplayName();
+                    }
+
+                    Workflow workflow = new Workflow(buildName, buildId, buildDescription, buildParametersMap);
+                    workflows.add(workflow);
+                }
+
+
+                // Send the response back to ActionHub
+                ObjectMapper mapper = new ObjectMapper();
+                mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+                String replyto = properties.getReplyTo();
+                AMQP.BasicProperties props = new AMQP.BasicProperties();
+                try {
+                    String jsonResponse = mapper.writeValueAsString(workflows);
+                    log.info("Replying on " + replyto + " with response: " + jsonResponse);
+                    channel.basicPublish("", replyto, props, jsonResponse.getBytes(Constants.CONTENT_TYPE_UTF_8));
+                } catch (Exception e) {
+                    log.info("Could not process return json: " + e.getMessage());
+                }
+            }
+        };
+
+        channel.basicConsume(queueName, true, actionsMsgConsumer);
+        log.info("Waiting for actions requests ...");
+    }
+    
+    private static void authenticate() {
+        //We will need to authenticate the plugin before we can read jenkins items 
+        GrantedAuthority[] authorities = new GrantedAuthority[]{SecurityRealm.AUTHENTICATED_AUTHORITY};
+        Authentication authentication = new UsernamePasswordAuthenticationToken("ActionHubPlugin", "", authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private static Set<Job> prepareJobList (String requestMessage) {
+        Set<Job> returnList = new HashSet<Job>();
+        TeamForgeShare.TeamForgeShareDescriptor descriptor = TeamForgeShare.getTeamForgeShareDescriptor();
+
+        boolean respondToGetActionsMessage = Util.respondsTo(
+                descriptor.getActionHubMsgIncludeRadio(),
+                descriptor.isActionHubMsgManual(),
+                descriptor.isActionHubMsgBuild(),
+                descriptor.isActionHubMsgCommit(),
+                descriptor.isActionHubMsgWorkitem(),
+                descriptor.isActionHubMsgReview(),
+                descriptor.isActionHubMsgCustom(),
+                descriptor.getActionHubMsgCustomTxt(),
+                requestMessage);
+
+        if (jenkins != null) {
+            authenticate();
+            // Get the list of jobs to send back to ActionHub. This includes projects, pipelines, etc.
+            List<Job> itemList = jenkins.getAllItems(Job.class);
+
+            if (itemList != null) {
+
+                if (respondToGetActionsMessage) {
+                    // put everything in the return list first
+                    for (Job item : itemList) {
+                        returnList.add(item);
+                    }
+                }
+
+                for (Job item : itemList) {
+                    //log.info(item.getName() + " -- " + item.getClass().toString());
+
+                    // apply per-job overrides
+                    Map<JobPropertyDescriptor, JobProperty> props = item.getProperties();
+
+                    for (JobProperty value : props.values()) {
+                        if (value instanceof Tagger) {
+                            Tagger tagger = (Tagger) value;
+
+                            if (tagger.isGlobalOverride()) {
+                                if (tagger.respondsTo(requestMessage)) {
+                                    returnList.add(item);
+                                } else {
+                                    returnList.remove(item);
+                                }
+                            }
+
+                        }
+                    }
+                }
+            }
+        } else {
+            log.info("Sorry Jenkins was null.");
+        }
+
+        return returnList;
+    }
+
+
+    // Overridden for better type safety.
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl)super.getDescriptor();
+    }
+
+    /**
+     * Descriptor for {@link ActionHubPlugin}. Used as a singleton.
+     * The class is marked as public so that it can be accessed from views.
+     *
+     */
+    @Extension // This indicates to Jenkins that this is an implementation of an extension point.
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+        /**
+         * In order to load the persisted global configuration, you have to 
+         * call load() in the constructor.
+         */
+        public DescriptorImpl() {
+            load();
+        }
+
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            // Indicates that this builder can be used with all kinds of project types
+            // Setting this to false as this is plugin is not meant to run as part of a build
+            return false;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Constants.PLUGIN_DISPLAY_NAME;
+        }
+
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            save();
+
+            return super.configure(req, formData);
+        }
+
+    }
+}
+

--- a/src/main/java/hudson/plugins/collabnet/actionhub/BuildCause.java
+++ b/src/main/java/hudson/plugins/collabnet/actionhub/BuildCause.java
@@ -1,0 +1,22 @@
+package hudson.plugins.collabnet.actionhub;
+
+import hudson.model.*;
+
+public class BuildCause extends Cause {
+
+    private final String queueName;
+    private final String ruleName;
+    private final String userName;
+
+    public BuildCause(String queueName, String ruleName, String userName) {
+        this.queueName = queueName;
+        this.ruleName = ruleName;
+        this.userName = userName;
+    }
+
+    @Override
+    public String getShortDescription() {
+        return "Triggered by ActionHub user '" + userName + "' using rule '" + ruleName + "' via remote build message from queue: " + queueName;
+    }
+
+}

--- a/src/main/java/hudson/plugins/collabnet/actionhub/Constants.java
+++ b/src/main/java/hudson/plugins/collabnet/actionhub/Constants.java
@@ -1,0 +1,63 @@
+package hudson.plugins.collabnet.actionhub;
+
+public class Constants {
+    public static final String PLUGIN_DISPLAY_NAME = "CollabNet ActionHub Plugin";
+
+    public static final String RABBIT_EXCHANGE_TYPE = "topic";
+    public static final String CONTENT_TYPE_UTF_8 = "UTF-8";
+    public static final String RABBIT_TIME_TO_LIVE_KEY = "x-message-ttl";
+    public static final int RABBIT_TIME_TO_LIVE_VALUE = 60000;
+    public static final String RABBIT_CONNECTION_NAME = "CollabNetActionHub";
+    static final int[] RABBIT_CONNECTION_RETRY_INTERVALS = {0, 1, 1, 2, 3, 5, 8, 13};
+
+    public static final String REQUEST_JSON_WORKFLOW_ID = "workflowId";
+    public static final String REQUEST_JSON_WORKFLOW_ARGUMENTS = "workflowArguments";
+    public static final String REQUEST_JSON_WORKFLOW_ARGUMENTS_NAME = "name";
+    public static final String REQUEST_JSON_WORKFLOW_ARGUMENTS_VALUE = "value";
+    public static final String REQUEST_JSON_RULE_INFO = "ruleInformation";
+    public static final String REQUEST_JSON_RULE_INFO_NAME = "ruleName";
+    public static final String REQUEST_JSON_USER_NAME = "userName";
+
+    public static final String JENKINS_CONFIG_ERROR_MSG_HOST = "Please set a host name for where the rabbit mq instance is running.";
+    public static final String JENKINS_CONFIG_ERROR_MSG_PORT = "Please set a port for where the rabbit mq instance is running.";
+    public static final String JENKINS_CONFIG_ERROR_USERNAME = "Enter a username to the rabbit mq instance.";
+    public static final String JENKINS_CONFIG_ERROR_PASSWORD = "Enter a password for the username above.";
+    public static final String JENKINS_CONFIG_ERROR_MSG_EXCHANGE = "Please set an exchange for where the rabbit mq instance is listening.";
+    public static final String JENKINS_CONFIG_ERROR_MSG_ROUTING_KEY_WF = "Please input the workflow routing key.";
+    public static final String JENKINS_CONFIG_ERROR_MSG_ROUTING_KEY_ACTIONS = "Please input the actions routing key.";
+
+
+    public static class ActionMessageType {
+        public static final String MANUAL = "MANUAL";
+        public static final String BUILD = "BUILD";
+        public static final String REVIEW = "REVIEW";
+        public static final String COMMIT = "COMMITCTF";
+        public static final String WORKITEM = "WORKITEM";
+        public static final String CUSTOM = "XDS";
+    }
+
+    public static class RadioButtonState {
+        public static final String ALL = "allinclude";
+        public static final String NONE = "noinclude";
+        public static final String CUSTOM = "custominclude";
+    }
+
+    public static class ParamDataTypes {
+        public static final String STRING = "string";
+        public static final String ENUM = "enum";
+    }
+
+
+    public static class TestJsonFiles {
+        public static final String WORKFLOW = "workflow_request.json";
+        public static final String ACTIONS_REQUEST = "actions_request.json";
+        public static final String ACTIONS_RESPONSE = "actions_response.json";
+    }
+
+    public static class TestProject {
+        // these values should correspond to the json in the test files above
+        public static final String ONE = "TestProject1";
+        public static final String TWO = "TestProject2";
+    }
+
+}

--- a/src/main/java/hudson/plugins/collabnet/actionhub/MQConnectionHandler.java
+++ b/src/main/java/hudson/plugins/collabnet/actionhub/MQConnectionHandler.java
@@ -1,0 +1,49 @@
+package hudson.plugins.collabnet.actionhub;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
+
+import lombok.extern.java.Log;
+
+@Log
+public class MQConnectionHandler implements ShutdownListener {
+
+    @Override
+    public void shutdownCompleted(ShutdownSignalException cause) {
+        boolean reConnectSuccess = true;
+        int count = 0;
+        log.info("Lost connection to RabbitMQ");
+
+        do {
+            int timeInterval = Constants.RABBIT_CONNECTION_RETRY_INTERVALS[count];
+
+            try {
+                TimeUnit.MINUTES.sleep(timeInterval);
+            } catch (InterruptedException ie) {
+                ie.printStackTrace();
+            }
+
+            log.info("Been " + timeInterval + " minute(s). Going to retry.");
+            reConnectSuccess = true; //assume try succeeded
+
+            try {
+                ActionHubPlugin.connectAndListen();
+            } catch (IOException ioe) {
+                reConnectSuccess = false;
+            } catch (TimeoutException te) {
+                reConnectSuccess = false;
+            }
+
+            count++;
+        } while (!reConnectSuccess && count < Constants.RABBIT_CONNECTION_RETRY_INTERVALS.length);
+
+        if (!reConnectSuccess) {
+            log.info("Unable to reconnect to Rabbit. Giving up.");
+        }
+
+    }
+}

--- a/src/main/java/hudson/plugins/collabnet/actionhub/Tagger.java
+++ b/src/main/java/hudson/plugins/collabnet/actionhub/Tagger.java
@@ -1,0 +1,136 @@
+package hudson.plugins.collabnet.actionhub;
+
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import hudson.plugins.collabnet.share.TeamForgeShare;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Tagger extends JobProperty {
+
+    private boolean globalOverride = false;
+    private String includeRadio = null;
+    private boolean manual = false;
+    private boolean workitem = false;
+    private boolean build = false;
+    private boolean review = false;
+    private boolean commit = false;
+    private boolean custom = false;
+    private String customMessages = null;
+
+    // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
+    @DataBoundConstructor
+    public Tagger(boolean globalOverride,
+                  String includeRadio,
+                  boolean manual,
+                  boolean workitem,
+                  boolean build,
+                  boolean review,
+                  boolean commit,
+                  boolean custom,
+                  String customMessages) {
+        this.globalOverride = globalOverride;
+        this.includeRadio = includeRadio;
+        this.manual = manual;
+        this.workitem = workitem;
+        this.build = build;
+        this.review = review;
+        this.commit = commit;
+        this.custom = custom;
+        this.customMessages = customMessages;
+    }
+
+    public boolean isGlobalOverride(){
+        return globalOverride;
+    }
+
+    public String getIncludeRadio() {
+        return includeRadio;
+    }
+
+    public boolean isManual() {
+        return manual;
+    }
+
+    public boolean isWorkitem(){
+        return workitem;
+    }
+
+    public boolean isBuild() {
+        return build;
+    }
+
+    public boolean isReview(){
+        return review;
+    }
+
+    public boolean isCommit() {
+        return commit;
+    }
+
+    public boolean isCustom(){
+        return custom;
+    }
+
+    public String getCustomMessages() {
+        return customMessages;
+    }
+
+    public boolean respondsTo(String requestMessage) {
+
+        return Util.respondsTo(includeRadio, manual, build, commit, workitem, review, custom, customMessages, requestMessage);
+
+    }
+
+
+
+    // Overridden for better type safety.
+    // If your plugin doesn't really define any property on Descriptor,
+    // you don't have to do this.
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl)super.getDescriptor();
+    }
+
+    @Extension // This indicates to Jenkins that this is an implementation of an extension point.
+    public static final class DescriptorImpl extends JobPropertyDescriptor {
+
+
+        /**
+         * In order to load the persisted global configuration, you have to
+         * call load() in the constructor.
+         */
+        public DescriptorImpl() {
+            load();
+        }
+
+
+        public boolean isApplicable(Class<? extends Job> aClass) {
+            // Indicates that this builder can be used with all kinds of project types
+            return true;
+        }
+
+        /**
+         * This human readable name is used in the configuration screen.
+         */
+        public String getDisplayName() {
+            return "ActionHub";
+        }
+
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            // To persist global configuration information,
+            // set that to properties and call save().
+            save();
+            return super.configure(req, formData);
+        }
+
+    }
+}
+

--- a/src/main/java/hudson/plugins/collabnet/actionhub/Util.java
+++ b/src/main/java/hudson/plugins/collabnet/actionhub/Util.java
@@ -1,0 +1,80 @@
+package hudson.plugins.collabnet.actionhub;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by nshah on 11/8/2016.
+ */
+public class Util {
+
+    public static boolean respondsTo(String radioButtonState,
+                                     boolean manualMessageCheckBox,
+                                     boolean buildMessageCheckBox,
+                                     boolean commitMessageCheckBox,
+                                     boolean workitemMessageCheckBox,
+                                     boolean reviewMessageCheckBox,
+                                     boolean customMessageCheckBox,
+                                     String customMessageString,
+                                     String requestMessage) {
+
+        if (radioButtonState.equals(Constants.RadioButtonState.ALL)) {
+            return true;
+        } else if (radioButtonState.equals(Constants.RadioButtonState.NONE)) {
+            return false;
+        } else if (radioButtonState.equals(Constants.RadioButtonState.CUSTOM)) {
+
+            List<String> messages = new ArrayList<String>();
+
+            if (manualMessageCheckBox) {
+                messages.add(Constants.ActionMessageType.MANUAL);
+            }
+
+            if (buildMessageCheckBox) {
+                messages.add(Constants.ActionMessageType.BUILD);
+            }
+
+            if (reviewMessageCheckBox) {
+                messages.add(Constants.ActionMessageType.REVIEW);
+            }
+
+            if (commitMessageCheckBox) {
+                messages.add(Constants.ActionMessageType.COMMIT);
+            }
+
+            if (workitemMessageCheckBox) {
+                messages.add(Constants.ActionMessageType.WORKITEM);
+            }
+
+            if (customMessageCheckBox) {
+
+                customMessageString = customMessageString.trim();
+                String[] customMessageTypes = new String[0];
+                if (customMessageString != null && customMessageString.length()>0) {
+                    customMessageTypes = customMessageString.split(",");
+                }
+
+                if (customMessageTypes.length > 0) {
+                    for (int i =0; i < customMessageTypes.length; i++) {
+                        messages.add(Constants.ActionMessageType.CUSTOM + "-" + customMessageTypes[i].trim().toUpperCase());
+                    }
+                } else {
+                    messages.add(Constants.ActionMessageType.CUSTOM);
+                }
+            }
+
+            if (messages.contains(requestMessage.toUpperCase())) {
+                return true;
+            }
+        }
+
+        return false;
+
+
+
+
+
+    }
+
+
+}

--- a/src/main/java/hudson/plugins/collabnet/actionhub/Workflow.java
+++ b/src/main/java/hudson/plugins/collabnet/actionhub/Workflow.java
@@ -1,0 +1,49 @@
+package hudson.plugins.collabnet.actionhub;
+
+import java.util.Map;
+
+public class Workflow {
+    String name;
+    String id;
+    String description;
+    Map<String, WorkflowParameter> parameters;
+    
+    public Workflow(String name, String id, String description, Map<String, WorkflowParameter> parameters) {
+        this.name = name;
+        this.id = id;
+        this.description = description;
+        this.parameters = parameters;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Map<String, WorkflowParameter> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, WorkflowParameter> parameters) {
+        this.parameters = parameters;
+    }
+}

--- a/src/main/java/hudson/plugins/collabnet/actionhub/WorkflowParameter.java
+++ b/src/main/java/hudson/plugins/collabnet/actionhub/WorkflowParameter.java
@@ -1,0 +1,39 @@
+package hudson.plugins.collabnet.actionhub;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WorkflowParameter {
+    String description;
+    boolean required;
+    String type;
+
+    @JsonProperty("default")
+    String default_val;
+
+    @JsonProperty("enum")
+    String[] enum_val;
+
+    public WorkflowParameter(String description, String type, String default_val, String[] enum_val) {
+        this.description = description;
+        this.required = false; //satisfies the workflow contract. jenkins has no concept of a required parameter. 
+        this.type = type;
+        this.default_val = default_val;
+        this.enum_val = enum_val.clone();
+    }
+
+    
+    // writing custom getter and setter for the enum_val variable
+    // because we need specific behavior that is not provided by Lombok
+    public String[] getEnum_val() {
+        return enum_val.clone();
+    }
+
+    public void setEnum_val (String[] enum_val) {
+        this.enum_val = enum_val.clone();
+    }
+    
+}

--- a/src/main/java/hudson/plugins/collabnet/share/TeamForgeShare.java
+++ b/src/main/java/hudson/plugins/collabnet/share/TeamForgeShare.java
@@ -6,10 +6,16 @@ import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.plugins.collabnet.ConnectionFactory;
+import hudson.plugins.collabnet.actionhub.ActionHubPlugin;
+import hudson.plugins.collabnet.actionhub.Constants;
+import hudson.util.FormValidation;
 import hudson.util.Secret;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.servlet.ServletException;
+import java.io.IOException;
 import java.util.logging.Logger;
 
 /**
@@ -52,6 +58,22 @@ public class TeamForgeShare extends JobProperty<Job<?, ?>> {
         private String username = null;
         private Secret password = null;
         private boolean useGlobal = false;
+        private String actionHubMqHost = null;
+        private int actionHubMqPort = 0;
+        private String actionHubMqUsername = null;
+        private String actionHubMqPassword = null;
+        private String actionHubMqExchange = null;
+        private String actionHubMqWorkflowQueue = null;
+        private String actionHubMqActionsQueue = null;
+        private String actionHubMsgIncludeRadio = null;
+        private boolean actionHubMsgManual = false;
+        private boolean actionHubMsgWorkitem = false;
+        private boolean actionHubMsgBuild = false;
+        private boolean actionHubMsgReview = false;
+        private boolean actionHubMsgCustom = false;
+        private boolean actionHubMsgCommit = false;
+        private String actionHubMsgCustomTxt = null;
+
     
         public TeamForgeShareDescriptor() {
             super(TeamForgeShare.class);
@@ -79,6 +101,36 @@ public class TeamForgeShare extends JobProperty<Job<?, ?>> {
             } else {
                 setConnectionFactory(null);
             }
+
+            if (json.has("actionHubMqHost")) {
+                actionHubMqHost = json.getString("actionHubMqHost");
+                actionHubMqPort = json.getInt("actionHubMqPort");
+                actionHubMqUsername = json.getString("actionHubMqUsername");
+                actionHubMqPassword = json.getString("actionHubMqPassword");
+                actionHubMqExchange = json.getString("actionHubMqExchange");
+                actionHubMqWorkflowQueue = json.getString("actionHubMqWorkflowQueue");
+                actionHubMqActionsQueue = json.getString("actionHubMqActionsQueue");
+
+                actionHubMsgIncludeRadio = (String)json.get("actionHubMsgIncludeRadio");
+                actionHubMsgManual = json.getBoolean("actionHubMsgManual");
+                actionHubMsgWorkitem = json.getBoolean("actionHubMsgWorkitem");
+                actionHubMsgCommit = json.getBoolean("actionHubMsgCommit");
+                actionHubMsgBuild = json.getBoolean("actionHubMsgBuild");
+                actionHubMsgReview = json.getBoolean("actionHubMsgReview");
+                actionHubMsgCustom = json.getBoolean("actionHubMsgCustom");
+                actionHubMsgCustomTxt = json.getString("actionHubMsgCustomTxt");
+
+                save();
+
+                log.info("ActionHub Connection Settings saved.");
+                try {
+                    ActionHubPlugin.init();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+            }
+
             return true; 
         }
 
@@ -96,6 +148,62 @@ public class TeamForgeShare extends JobProperty<Job<?, ?>> {
             save();
         }
 
+        //Next few methods perform on-the-fly validation of the various form fields.
+        public FormValidation doCheckActionHubMqHost(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (value.length() == 0)
+                return FormValidation.error(Constants.JENKINS_CONFIG_ERROR_MSG_HOST);
+
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckActionHubMqPort(@QueryParameter int value)
+                throws IOException, ServletException {
+            if (value < 1)
+                return FormValidation.error(Constants.JENKINS_CONFIG_ERROR_MSG_PORT);
+
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckActionHubMqUsername(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (value.length() == 0)
+                return FormValidation.error(Constants.JENKINS_CONFIG_ERROR_USERNAME);
+
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckActionHubMqPassword(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (value.length() == 0)
+                return FormValidation.error(Constants.JENKINS_CONFIG_ERROR_PASSWORD);
+
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckActionHubMqExchange(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (value.length() == 0)
+                return FormValidation.error(Constants.JENKINS_CONFIG_ERROR_MSG_EXCHANGE);
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckActionHubMqWorkflowQueue(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (value.length() == 0)
+                return FormValidation.error(Constants.JENKINS_CONFIG_ERROR_MSG_ROUTING_KEY_WF);
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckActionHubMqActionsQueue(@QueryParameter String value)
+                throws IOException, ServletException {
+            if (value.length() == 0)
+                return FormValidation.error(Constants.JENKINS_CONFIG_ERROR_MSG_ROUTING_KEY_ACTIONS);
+            return FormValidation.ok();
+        }
+
+
+
         public boolean useGlobal() {
             return this.useGlobal;
         }
@@ -112,8 +220,94 @@ public class TeamForgeShare extends JobProperty<Job<?, ?>> {
             return Secret.toString(this.password);
         }
 
+        public String getActionHubMqHost() {
+            return this.actionHubMqHost;
+        }
+
+        public int getActionHubMqPort() {
+            return this.actionHubMqPort;
+        }
+
+        public String getActionHubMqUsername() {
+            return this.actionHubMqUsername;
+        }
+
+        public String getActionHubMqPassword() {
+            return this.actionHubMqPassword;
+        }
+
+        public String getActionHubMqExchange() {
+            return this.actionHubMqExchange;
+        }
+
+        public String getActionHubMqWorkflowQueue() {
+            return this.actionHubMqWorkflowQueue;
+        }
+
+        public String getActionHubMqActionsQueue() {
+            return this.actionHubMqActionsQueue;
+        }
+
         public ConnectionFactory getConnectionFactory() {
             return useGlobal ? new ConnectionFactory(collabNetUrl,username,password) : null;
+        }
+
+        public String getActionHubMsgIncludeRadio() {
+            return actionHubMsgIncludeRadio;
+        }
+
+        public void setActionHubMsgIncludeRadio(String actionHubMsgIncludeRadio) {
+            this.actionHubMsgIncludeRadio = actionHubMsgIncludeRadio;
+        }
+
+        public boolean isActionHubMsgManual() {
+            return actionHubMsgManual;
+        }
+
+        public boolean isActionHubMsgWorkitem() {
+            return actionHubMsgWorkitem;
+        }
+
+        public boolean isActionHubMsgCommit() {
+            return actionHubMsgCommit;
+        }
+
+        public boolean isActionHubMsgBuild() {
+            return actionHubMsgBuild;
+        }
+
+        public boolean isActionHubMsgReview() {
+            return actionHubMsgReview;
+        }
+
+        public boolean isActionHubMsgCustom() {
+            return actionHubMsgCustom;
+        }
+
+        public String getActionHubMsgCustomTxt() {
+            return actionHubMsgCustomTxt;
+        }
+
+        public boolean areActionHubSettingsValid () {
+            boolean retVal=true;
+
+            if (actionHubMqHost==null || actionHubMqHost.length() == 0) {
+                retVal = false;
+            } else if (actionHubMqPort < 1) {
+                retVal = false;
+            } else if (actionHubMqUsername==null || actionHubMqUsername.length() == 0) {
+                retVal = false;
+            } else if (actionHubMqPassword==null || actionHubMqPassword.length() == 0) {
+                retVal = false;
+            } else if (actionHubMqExchange==null || actionHubMqExchange.length() == 0) {
+                retVal = false;
+            } else if (actionHubMqWorkflowQueue==null || actionHubMqWorkflowQueue.length() == 0) {
+                retVal = false;
+            } else if (actionHubMqActionsQueue==null || actionHubMqActionsQueue.length() == 0) {
+                retVal = false;
+            }
+
+            return retVal;
         }
     }
 }

--- a/src/main/resources/hudson/plugins/collabnet/actionhub/Tagger/config.jelly
+++ b/src/main/resources/hudson/plugins/collabnet/actionhub/Tagger/config.jelly
@@ -1,0 +1,44 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:block>
+    <f:optionalBlock name="globalOverride" checked="${instance.globalOverride}" title="Override ActionHub global response settings" inline="true">
+
+      <f:entry>
+        <f:radio name="includeRadio" title="Include this job in response to all messages." value="allinclude"  checked="${instance.includeRadio == 'allinclude'}" />
+      </f:entry>
+      <f:entry>
+        <f:radio name="includeRadio" title="Do not include this job in ActionHub responses." value="noinclude"  checked="${instance.includeRadio == 'noinclude'}" />
+      </f:entry>
+      <f:entry>
+        <f:radio name="includeRadio" title="Custom. Include this job in response to the following messages." value="custominclude"  checked="${instance.includeRadio == 'custominclude'}" />
+      </f:entry>
+
+      <f:nested>
+        <f:entry title="Manual: " field="manual" checked="${instance.manual}">
+          <f:checkbox  />
+        </f:entry>
+        <f:entry title="Commit: " field="commit" checked="${instance.commit}">
+          <f:checkbox  />
+        </f:entry>
+        <f:entry title="Work Item: " field="workitem" checked="${instance.workitem}">
+          <f:checkbox  />
+        </f:entry>
+        <f:entry title="Build: " field="build" checked="${instance.build}">
+          <f:checkbox  />
+        </f:entry>
+          <f:entry title="Review: " field="review" checked="${instance.review}">
+        <f:checkbox  />
+        </f:entry>
+          <f:entry title="Custom: " field="custom" checked="${instance.custom}">
+        <f:checkbox  />
+          </f:entry>
+        <f:entry field="customMessages" description="A comma separated list of Custom (XDS) sources.">
+          <f:textbox />
+        </f:entry>
+      </f:nested>
+
+    </f:optionalBlock>
+  </f:block>
+
+</j:jelly>

--- a/src/main/resources/hudson/plugins/collabnet/actionhub/Tagger/help-customMessages.html
+++ b/src/main/resources/hudson/plugins/collabnet/actionhub/Tagger/help-customMessages.html
@@ -1,0 +1,3 @@
+<div>
+    Insert custom XDS message types here.  This should correspond to the type name displayed in the source selection tree in ActionHub.  This might look something like "Package Schema,Health Schema" if those are the custom schema types where this job should be included.
+</div>

--- a/src/main/resources/hudson/plugins/collabnet/share/TeamForgeShare/global.jelly
+++ b/src/main/resources/hudson/plugins/collabnet/share/TeamForgeShare/global.jelly
@@ -6,4 +6,70 @@
   <f:section title="Global CollabNet Configuration">
     <f:optionalProperty field="connectionFactory" title="Allow Global CollabNet Configuration"/>
   </f:section>
+
+  <f:section title="CollabNet ActionHub Connectivity Settings">
+
+    <f:entry title="RabbitMQ Host" field="actionHubMqHost">
+      <f:textbox />
+    </f:entry>
+
+    <f:entry title="RabbitMQ Port" field="actionHubMqPort">
+      <f:textbox />
+    </f:entry>
+
+    <f:entry title="RabbitMQ Username" field="actionHubMqUsername">
+      <f:textbox />
+    </f:entry>
+
+    <f:entry title="RabbitMQ Password" field="actionHubMqPassword">
+      <f:password />
+    </f:entry>
+
+    <f:entry title="RabbitMQ Exchange" field="actionHubMqExchange" description="Which Exchange to listen on">
+      <f:textbox />
+    </f:entry>
+
+    <f:entry title="Workflow Queue" field="actionHubMqWorkflowQueue" description="Queue on which to listen for workflow messages.">
+      <f:textbox />
+    </f:entry>
+
+    <f:entry title="Actions Queue" field="actionHubMqActionsQueue" description="Queue on which to listen for get actions requests.">
+      <f:textbox />
+    </f:entry>
+
+    <f:entry title="How to respond to get actions requests:" field="actionHubMsgIncludeRadio">
+      <f:entry>
+        <f:radio name="actionHubMsgIncludeRadio" title="Respond to all message types." value="allinclude"  checked="${instance.actionHubMsgIncludeRadio == 'allinclude'}" />
+      </f:entry>
+      <f:entry>
+        <f:radio name="actionHubMsgIncludeRadio" title="Do not respond to actions requests." value="noinclude"  checked="${instance.actionHubMsgIncludeRadio == 'noinclude'}" />
+      </f:entry>
+      <f:entry>
+        <f:radio name="actionHubMsgIncludeRadio" title="Custom. Respond only to the following message types." value="custominclude"  checked="${instance.actionHubMsgIncludeRadio == 'custominclude'}" />
+      </f:entry>
+    </f:entry>
+
+    <f:entry title="Manual:" field="actionHubMsgManual" >
+      <f:checkbox  />
+    </f:entry>
+    <f:entry title="Commit:" field="actionHubMsgCommit" >
+      <f:checkbox  />
+    </f:entry>
+    <f:entry title="Work Item:" field="actionHubMsgWorkitem" >
+      <f:checkbox  />
+    </f:entry>
+    <f:entry title="Build:" field="actionHubMsgBuild" >
+      <f:checkbox  />
+    </f:entry>
+    <f:entry title="Review:" field="actionHubMsgReview" >
+      <f:checkbox  />
+    </f:entry>
+    <f:entry title="Custom:" field="actionHubMsgCustom" >
+      <f:checkbox  />
+    </f:entry>
+    <f:entry field="actionHubMsgCustomTxt" description="A comma separated list of Custom (XDS) sources.">
+      <f:textbox />
+    </f:entry>
+
+  </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/collabnet/share/TeamForgeShare/help-actionHubMsgCustom.html
+++ b/src/main/resources/hudson/plugins/collabnet/share/TeamForgeShare/help-actionHubMsgCustom.html
@@ -1,0 +1,3 @@
+<div>
+    Insert custom XDS message types here.  This should correspond to the type name displayed in the source selection tree in ActionHub.  This might look something like "Package Schema,Health Schema" if those are the custom schema types where this job should be included.
+</div>

--- a/src/test/java/hudson/plugins/collabnet/actionhub/ActionHubPluginTest.java
+++ b/src/test/java/hudson/plugins/collabnet/actionhub/ActionHubPluginTest.java
@@ -1,0 +1,180 @@
+package hudson.plugins.collabnet.actionhub;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.byteThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+import com.rabbitmq.client.*;
+import com.rabbitmq.tools.json.JSONReader;
+import hudson.plugins.collabnet.share.TeamForgeShare;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.ExtensionList;
+import hudson.model.*;
+import jenkins.model.Jenkins;
+import lombok.extern.java.Log;
+import org.kohsuke.stapler.RequestImpl;
+import org.kohsuke.stapler.StaplerRequest;
+import org.mockito.AdditionalMatchers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+
+@Log
+public class ActionHubPluginTest {
+    @Rule public JenkinsRule j = new JenkinsRule();
+    Channel mockedChannel;
+    AMQP.BasicProperties props;
+    FreeStyleProject project1, project2;
+    Envelope envelope;
+    String someStr = "test";
+
+
+    @Before
+    public void setup() {
+        try {
+            TeamForgeShare.TeamForgeShareDescriptor descriptor = TeamForgeShare.getTeamForgeShareDescriptor();
+            descriptor.setActionHubMsgIncludeRadio(Constants.RadioButtonState.ALL);
+
+            // Create some test projects in Jenkins
+            project1 = j.createFreeStyleProject(Constants.TestProject.ONE);
+            project2 = j.createFreeStyleProject(Constants.TestProject.TWO);
+
+            // mock rabbitMQ calls
+            mockedChannel = mock(Channel.class);
+            AMQP.Queue.DeclareOk declareOK = mock(AMQP.Queue.DeclareOk.class);
+            when(declareOK.getQueue()).thenReturn(someStr);
+            when(mockedChannel.queueDeclare()).thenReturn(declareOK);
+            props = mock(AMQP.BasicProperties.class);
+            when(props.getReplyTo()).thenReturn(someStr);
+            envelope = mock(Envelope.class);
+            when(envelope.getRoutingKey()).thenReturn(someStr);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    @Test
+    public void testPluginInitialize()  {
+        boolean pluginInitialized = false;
+
+        // get a list of plugin descriptors
+        ExtensionList<Descriptor> extensions = Jenkins.getInstance().getExtensionList(Descriptor.class);
+        
+        for (Descriptor extension : extensions) {
+            log.info(extension.getDisplayName());
+            
+            if (extension.getDisplayName() == Constants.PLUGIN_DISPLAY_NAME) {
+                // our plugin has been initialized
+                pluginInitialized = true;
+                break;
+            }
+        }
+
+        assertTrue(pluginInitialized);
+    }
+
+    @Test
+    public void testReadWorkflowMsgAndTriggerBuild() {
+        // Read test workflow JSON from file
+        String testWorkflowJson = readtestJson(Constants.TestJsonFiles.WORKFLOW);
+
+        try {
+            // Parse the test workflow JSON
+            JSONReader jsonParser = new JSONReader();
+            Map<String, Object> request = (Map<String, Object>) jsonParser.read(testWorkflowJson);
+            String testWorkFlowId = (String) request.get(Constants.REQUEST_JSON_WORKFLOW_ID);
+            List<HashMap> passedInParameters = (ArrayList<HashMap>) request.get(Constants.REQUEST_JSON_WORKFLOW_ARGUMENTS);
+            int testParamCount = passedInParameters.size();
+            StringParameterValue testParam1 = new StringParameterValue((String) passedInParameters.get(0).get(Constants.REQUEST_JSON_WORKFLOW_ARGUMENTS_NAME),
+                    (String) passedInParameters.get(0).get(Constants.REQUEST_JSON_WORKFLOW_ARGUMENTS_VALUE));
+            StringParameterValue testParam2 = new StringParameterValue((String) passedInParameters.get(1).get(Constants.REQUEST_JSON_WORKFLOW_ARGUMENTS_NAME),
+                    (String) passedInParameters.get(1).get(Constants.REQUEST_JSON_WORKFLOW_ARGUMENTS_VALUE));
+
+            // simulate reading a new workflow message and trigger a build
+            ActionHubPlugin.channel = mockedChannel;
+            ActionHubPlugin.initWorkflowQueueListener(someStr, someStr);
+            ActionHubPlugin.workflowMsgConsumer.handleDelivery(someStr, envelope, props, testWorkflowJson.getBytes(Constants.CONTENT_TYPE_UTF_8));
+            TimeUnit.SECONDS.sleep(10); //give it a few seconds for build to complete
+
+            // test assertions
+            FreeStyleBuild lastBuild = project1.getLastBuild();
+            assertNotNull(lastBuild);
+            Result lastBuildResult = lastBuild.getResult();
+            List<ParametersAction> actions = lastBuild.getActions(ParametersAction.class);
+            List<ParameterValue> lastBuildParameters = actions.get(0).getParameters();
+            assertEquals(testParamCount, lastBuildParameters.size());
+            assertTrue(lastBuildParameters.contains(testParam1));
+            assertTrue(lastBuildParameters.contains(testParam2));
+            assertEquals(Result.SUCCESS, lastBuildResult);
+        } catch (IOException e1) {
+            e1.printStackTrace();
+        } catch (InterruptedException ie) {
+            ie.printStackTrace();
+        }
+    }
+
+
+    @Test
+    public void testReadActionsMsgAndRespond() {
+        //read test JSON for getActions request and response
+        String getActionsJsonTestRequest = readtestJson(Constants.TestJsonFiles.ACTIONS_REQUEST);
+        String expectedGetActionsJsonResponse = readtestJson(Constants.TestJsonFiles.ACTIONS_RESPONSE);
+
+
+        try {
+            ArgumentCaptor<byte[]> argument = ArgumentCaptor.forClass(byte[].class);
+
+            // this call will simulate reading a get actions request and generate a response
+            ActionHubPlugin.channel = mockedChannel;
+            ActionHubPlugin.initActionsQueueListener(someStr, someStr);
+            ActionHubPlugin.actionsMsgConsumer.handleDelivery(someStr, envelope, props, getActionsJsonTestRequest.getBytes(Constants.CONTENT_TYPE_UTF_8));
+
+            // assertion
+            verify(mockedChannel).basicPublish(anyString(), anyString(), (AMQP.BasicProperties)any(), argument.capture());
+            String actualGetActionsJsonResponse = new String(argument.getValue(), Constants.CONTENT_TYPE_UTF_8);
+
+            JSONReader jsonParser = new JSONReader();
+            ArrayList expectedJobs =  (ArrayList)jsonParser.read(expectedGetActionsJsonResponse);
+            ArrayList actualJobs =  (ArrayList)jsonParser.read(actualGetActionsJsonResponse);
+
+            for (Object expectedJob:expectedJobs) {
+                assertTrue(actualJobs.contains(expectedJob));
+            }
+
+        } catch (IOException e1) {
+            e1.printStackTrace();
+        }
+    }
+
+    private String readtestJson(String fileName) {
+        String retval = "";
+
+        try {
+            retval =  IOUtils.toString(this.getClass().getResourceAsStream(fileName), Constants.CONTENT_TYPE_UTF_8);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return retval;
+    }
+
+}

--- a/src/test/resources/hudson/plugins/collabnet/actionhub/actions_request.json
+++ b/src/test/resources/hudson/plugins/collabnet/actionhub/actions_request.json
@@ -1,0 +1,1 @@
+{"requestType":"GetActions","messageType":"Manual"}

--- a/src/test/resources/hudson/plugins/collabnet/actionhub/actions_response.json
+++ b/src/test/resources/hudson/plugins/collabnet/actionhub/actions_response.json
@@ -1,0 +1,1 @@
+[{"name":"TestProject1","id":"TestProject1"},{"name":"TestProject2","id":"TestProject2"}]

--- a/src/test/resources/hudson/plugins/collabnet/actionhub/workflow_request.json
+++ b/src/test/resources/hudson/plugins/collabnet/actionhub/workflow_request.json
@@ -1,0 +1,27 @@
+{
+   "workflowId":"TestProject1",
+   "workflowName":"TestProject1",
+   "workflowArguments":[
+      {
+         "name":"TestParameter2",
+         "value":"two"
+      },
+      {
+         "name":"TestParameter1",
+         "value":"value1"
+      }
+   ],
+   "originalMessage":"{}",
+   "senderInformation":{
+      "port":8187,
+      "hostName":"nshah-p50",
+      "senderType":"Manual"
+   },
+   "ruleInformation":{
+      "ruleId":14,
+      "ruleUUID":"52c9ed4c-af42-490d-90d6-752e43c09dc1",
+      "ruleName":"jenkinsTest",
+      "userName":"admin",
+      "processedTime":"Tue Oct 11 08:31:44 UTC 2016"
+   }
+}


### PR DESCRIPTION
I am contributing the code for the ActionHub Jenkins plugin.
I am adding the following files:
pom.xml - Upgrade the amqp-client dependency from ver 3.6.1 to ver 3.6.5. Add dependencies for mockito, jackson, and lombok.

ActionHubPlugin.java - This contains the bulk of the code.

    Opens a rabbitMQ connection
    Listens on two queues – ws and actions
    On the actions queue, it receives json requests for a list of builds that Jenkins is set up to do
    On the ws queue, it receives json requests to trigger a build which it then triggers

BuildCause.java - Cause object that indicates why a build was triggered.
Constants.java - Contains constants
MQConnectionHandler.java - Handler for when connection to MQ is dropped. Retries every few minutes.
Workflow.java and WorkflowParameter.java - Model objects
Tagger.java - Tags individual projects 

ActionHubPluginTest.java - Unit tests
actions_request.json, actions_response.json, workflow_request.json - json data to be used in unit tests.

These are the changes to your files:
TeamForgeShare.java and global.jelly - Adding configuration settings for our functionality.

Thanks
