### PR TITLE
Custom pipeline step to notify EventQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,17 @@
       <artifactId>workflow-job</artifactId>
       <version>2.9</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>1.22</version>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/hudson/plugins/collabnet/actionhub/ActionHubPlugin.java
+++ b/src/main/java/hudson/plugins/collabnet/actionhub/ActionHubPlugin.java
@@ -112,7 +112,8 @@ public class ActionHubPlugin extends Builder {
         }
 
         TeamForgeShare.TeamForgeShareDescriptor descriptor = TeamForgeShare.getTeamForgeShareDescriptor();
-        if (descriptor.areActionHubSettingsValid() == true) {
+        if (descriptor != null // possible when plugin is first installed 
+                && descriptor.areActionHubSettingsValid() == true) {
             ConnectionFactory factory = new ConnectionFactory();
             factory.setHost(descriptor.getActionHubMqHost().trim());
             factory.setPort(descriptor.getActionHubMqPort());

--- a/src/main/java/hudson/plugins/collabnet/orchestrate/BuildToJSON.java
+++ b/src/main/java/hudson/plugins/collabnet/orchestrate/BuildToJSON.java
@@ -16,7 +16,7 @@
 
 package hudson.plugins.collabnet.orchestrate;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
@@ -46,7 +46,17 @@ public interface BuildToJSON {
      * @return JSONObject representing the 'buildData' element in the message JSON
      * @throws IOException
      */
-    public JSONObject getBuildData(AbstractBuild build) throws IOException;
+    public JSONObject getBuildData(Run build) throws IOException;
+
+    /**
+     * Construct the payload of the JSON Message.
+     *
+     * @param build the build being reported
+     * @param eventqStatus the EventQ status to use
+     * @return JSONObject representing the 'buildData' element in the message JSON
+     * @throws IOException
+     */
+    public JSONObject getBuildData(Run run, String eventqStatus, boolean excludeCommitInfo) throws IOException;     
 
     /**
      * Convert the SCM URL to something without credentials.
@@ -60,7 +70,7 @@ public interface BuildToJSON {
      * @param build AbstractBuild
      * @return JSONObject or null if there are no results
      */
-    JSONObject getTestResults(AbstractBuild build);
+    JSONObject getTestResults(Run build);
 
     /**
      * Build a status JSON object from the given build
@@ -68,17 +78,17 @@ public interface BuildToJSON {
      * @param build AbstractBuild
      * @return JSONObject containing the type and name
      */
-    JSONObject getStatus(AbstractBuild build);
+    JSONObject getStatus(Run build);
 
     /**
      * Because Jenkins is a pain in the ass to mock...
      *
      *
-     * @param build AbstractBuild we're grabbing the URI for
+     * @param run Run we're grabbing the URI for
      * @return URI for the build HTML page
      * @throws java.net.URISyntaxException
      */
-    URI getBuildURI(AbstractBuild build) throws URISyntaxException;
+    URI getBuildURI(Run run) throws URISyntaxException;
 
     /**
      * Generate the JSON for the revision information.
@@ -88,7 +98,7 @@ public interface BuildToJSON {
      * @return
      * @throws IOException
      */
-    JSONArray getRevisions(AbstractBuild build) throws IOException;
+    JSONArray getRevisions(Run build) throws IOException;
 
     /**
      * Generate a partial JSON for the revision information.
@@ -98,7 +108,7 @@ public interface BuildToJSON {
      * @return
      * @throws IOException
      */
-    JSONObject getRepositoryInfo(AbstractBuild build) throws IOException;
+    JSONObject getRepositoryInfo(Run build) throws IOException;
 
     /**
      * Converts the standard timestamp from Java format to EventQ's format.

--- a/src/main/java/hudson/plugins/collabnet/orchestrate/BuildToOrchestrateAPI.java
+++ b/src/main/java/hudson/plugins/collabnet/orchestrate/BuildToOrchestrateAPI.java
@@ -16,7 +16,7 @@
 
 package hudson.plugins.collabnet.orchestrate;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import java.io.IOException;
 
@@ -32,6 +32,18 @@ public interface BuildToOrchestrateAPI {
      * @return the JSON formatted data
      * @throws IOException if an error occurs converting the build to a JSON object
      */
-    public String toOrchestrateAPI(AbstractBuild build, String sourceKey) throws IOException;
+    public String toOrchestrateAPI(Run build, String sourceKey) throws IOException;
 
+    /**
+     * Converts the given build to the format used by the EventQ API.
+     *
+     * @param build Run.
+     * @param sourceKey the key to use to identify this server to the EventQ API.
+     * @param status EventQ status to report.
+     * @param excludeCommitInfo whether to exclude commit info
+     * @return the JSON formatted data
+     * @throws IOException if an error occurs converting the build to a JSON object
+     */
+    public String toOrchestrateAPI(Run build, String sourceKey, String status, boolean excludeCommitInfo)
+            throws IOException;
 }

--- a/src/main/java/hudson/plugins/collabnet/orchestrate/DefaultBuildToOrchestrateAPI.java
+++ b/src/main/java/hudson/plugins/collabnet/orchestrate/DefaultBuildToOrchestrateAPI.java
@@ -16,7 +16,7 @@
 
 package hudson.plugins.collabnet.orchestrate;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import net.sf.json.JSONObject;
 
 import java.io.IOException;
@@ -42,11 +42,17 @@ public class DefaultBuildToOrchestrateAPI implements BuildToOrchestrateAPI {
     }
 
     /** {@inheritDoc} */
-    public String toOrchestrateAPI(AbstractBuild build, String sourceKey) throws IOException {
+    public String toOrchestrateAPI(Run build, String sourceKey) throws IOException {
+        return toOrchestrateAPI(build, sourceKey, null, false);
+    }
+
+    /** {@inheritDoc} */
+    public String toOrchestrateAPI(Run build, String sourceKey, String status, boolean excludeCommitInfo)
+            throws IOException {
         JSONObject response = new JSONObject()
                 .element("api_version", "1")
                 .element("source_association_key", sourceKey)
-                .element("build_data", converter.getBuildData(build));
+                .element("build_data", converter.getBuildData(build, status, excludeCommitInfo));
 
         return response.toString();
     }

--- a/src/main/java/jenkins/plugins/collabnet/steps/PublishEventQStep.java
+++ b/src/main/java/jenkins/plugins/collabnet/steps/PublishEventQStep.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2017 CollabNet, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jenkins.plugins.collabnet.steps;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import com.google.common.collect.ImmutableSet;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.collabnet.orchestrate.AmqpOrchestrateClient;
+import hudson.plugins.collabnet.orchestrate.BuildToOrchestrateAPI;
+import hudson.plugins.collabnet.orchestrate.DefaultBuildToJSON;
+import hudson.plugins.collabnet.orchestrate.DefaultBuildToOrchestrateAPI;
+import hudson.plugins.collabnet.orchestrate.OrchestrateClient;
+import hudson.plugins.collabnet.share.TeamForgeShare;
+import hudson.plugins.collabnet.share.TeamForgeShare.TeamForgeShareDescriptor;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+
+public class PublishEventQStep extends Step {
+
+    /** The root URL to the EventQ or MQ server. */
+    private final String serverUrl;
+
+    private String credentialsId;
+
+    /** The key to the source to publish the build to. */
+    @DataBoundSetter public String sourceKey;
+
+    /** The flag to mark current run unstable if this step fails to notify EventQ. */
+    @DataBoundSetter public boolean markUnstable;
+
+    /** The (optional) status to report explicitly to EventQ. */
+    @DataBoundSetter public String status;
+
+    /** The flag to control whether to exclude associated commit info in the EventQ notification. */
+    @DataBoundSetter public boolean excludeCommitInfo;
+
+    @DataBoundConstructor
+    public PublishEventQStep(String serverUrl) {
+        this.serverUrl = serverUrl;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        PublishEventQStepExecution execution = new PublishEventQStepExecution(this, context);
+        return execution;
+    }
+
+    /**
+     * Reads the server URL to contact. Used by Jelly to render the UI template.
+     *
+     * @return the server URL
+     */
+    public String getServerUrl() {
+        return serverUrl;
+    }
+
+    public String getCredentialsId() {
+        return this.credentialsId;
+    }
+
+    @DataBoundSetter public void setCredentialsId(String credentialsId) {
+        this.credentialsId = credentialsId;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "publishEventQ";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Notify TeamForge EventQ";
+        }
+
+        @Override
+        public Set<Class<?>> getRequiredContext() {
+            return ImmutableSet.of(Run.class, TaskListener.class, EnvVars.class);
+        }
+
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item owner) {
+            if (owner == null || !owner.hasPermission(Item.CONFIGURE)) {
+                return new StandardUsernameListBoxModel().withEmptySelection();
+            }
+            String useServerUrl = null;
+            return new StandardUsernameListBoxModel()
+                    .withEmptySelection()
+                    .withAll(PublishEventQStepExecution.lookupCredentials(owner, useServerUrl));
+        }
+
+        public ListBoxModel doFillStatusItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("-- Auto --", "");
+            items.add("SUCCESS", "SUCCESS");
+            items.add("UNSTABLE", "UNSTABLE");
+            items.add("ABORTED", "ABORTED");
+            items.add("FAILURE", "FAILURE");
+            return items;
+        }
+
+        /**
+         * Validates that the user provided a server URL.
+         *
+         * @param serverUrl
+         *            the URL provided by the user
+         * @return whether or not the validation succeeded
+         */
+        public FormValidation doCheckServerUrl(@QueryParameter String serverUrl) {
+            return FormValidation.validateRequired(serverUrl);
+        }
+
+        /**
+         * Validates that the user provided a source key.
+         *
+         * @param sourceKey
+         *            the key provided by the user
+         * @return whether or not the validation succeeded
+         */
+        public FormValidation doCheckSourceKey(@QueryParameter String sourceKey) {
+            return FormValidation.validateRequired(sourceKey);
+        }
+
+        /**
+         * Validates that the user provided EventQ status.
+         *
+         * @param status
+         *            the status provided by the user
+         * @return whether or not the validation succeeded
+         */
+        public FormValidation doCheckStatus(@QueryParameter String status) {
+            if (isBlank(status) // empty is ok
+                    || status.toLowerCase().startsWith("success")
+                    || status.toLowerCase().equals("unstable")
+                    || status.toLowerCase().equals("aborted")
+                    || status.toLowerCase().startsWith("fail")
+                    ) {
+                return FormValidation.ok();
+            }
+            return FormValidation.error("Invalid EventQ status value");
+        }
+
+        public FormValidation doCheckCredentialsId(
+                @QueryParameter final String credentialsId,
+                @AncestorInPath final Item owner) {
+            // TODO make sure that fallback credentials (i.e. TeamForge) exists if
+            // none is selected
+            return FormValidation.ok();
+        }
+    }
+
+    public static class PublishEventQStepExecution extends SynchNonBlockingStepExecution<Void> {
+        private static final long serialVersionUID = 1L;
+        private static final Logger logger = Logger.getLogger(PublishEventQStepExecution.class.getName());
+
+        private transient PublishEventQStep step;
+        private transient TaskListener listener;
+        private transient Run<?,?> run;
+
+        private transient BuildToOrchestrateAPI converter;
+        private transient OrchestrateClient eventqClient;
+        
+        /** Prefix for messages appearing in the console log, for readability */
+        public static String LOG_MESSAGE_PREFIX = "TeamForge EventQ Build Notifier - ";
+
+        /** Message for invalid EventQ server URL */
+        public static String LOG_MESSAGE_INVALID_URL = "The URL to the TeamForge EventQ server is missing.";
+
+        /** Message for invalid EventQ source identifier */
+        public static String LOG_MESSAGE_INVALID_SOURCE_KEY =
+                "The source key for the TeamForge EventQ build source is missing.";
+
+        public PublishEventQStepExecution(final PublishEventQStep step, @Nonnull final StepContext ctx)
+                throws IOException, InterruptedException {
+            super(ctx);
+            this.step = step;
+            this.listener = getContext().get(TaskListener.class);
+            this.run = getContext().get(Run.class);
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            PrintStream consoleLogger = this.listener.getLogger();
+            String serverUrl = this.step.getServerUrl();
+            if (isBlank(serverUrl)) {
+                markUnstable(
+                        consoleLogger,
+                        "Build information NOT sent: " + LOG_MESSAGE_INVALID_URL);
+                return null;
+            }
+
+            String srcKey = this.step.sourceKey;
+            if (isBlank(srcKey)) {
+                markUnstable(
+                        consoleLogger,
+                        "Build information NOT sent: " + LOG_MESSAGE_INVALID_SOURCE_KEY);
+                return null;
+            }
+
+            try {
+                initialize();
+                log("Sending build information using "
+                        + eventqClient.getClass().getSimpleName(),
+                        consoleLogger);
+                String json = converter.toOrchestrateAPI(run, srcKey.trim(), this.step.status,
+                        this.step.excludeCommitInfo);
+                StandardUsernamePasswordCredentials c = getCredentials();
+                String username = c == null ? null : c.getUsername();
+                String password = c == null ?
+                        null : (c.getPassword() == null ? null : c.getPassword().getPlainText());
+                if (c == null) {
+                    // fallback to TeamForge credentials
+                    TeamForgeShareDescriptor d = TeamForgeShare.getTeamForgeShareDescriptor();
+                    username = d.getUsername();
+                    password = d.getPassword();
+
+                }
+                // log("Build information: " + json, consoleLogger);
+                eventqClient.postBuild(serverUrl.trim(),
+                        username, password, json);
+                log("Build information sent", consoleLogger);
+            } catch (IllegalStateException ise) {
+                markUnstable(consoleLogger,
+                        "Build information NOT sent: this step needs a Jenkins URL " +
+                        "(go to Manage Jenkins > Configure System; click Save)");
+                ise.printStackTrace(consoleLogger);
+
+            } catch (Exception e) {
+                markUnstable(consoleLogger, e.getMessage());
+                log("Build information NOT sent, details below", consoleLogger);
+                e.printStackTrace(consoleLogger);
+            }
+            return null;
+        }
+
+        /**
+         * Marks the current run as unstable and logs a message.
+         * 
+         * @param consoleLogger
+         *            the logger to log to
+         * @param message
+         *            the message to log
+         */
+        private void markUnstable(PrintStream consoleLogger, String message) {
+            log(message, consoleLogger);
+            logger.warning(message);
+            if (this.step == null || this.step.markUnstable) {
+                if (this.run != null) {
+                    this.run.setResult(Result.UNSTABLE);
+                }
+            }
+        }
+        
+        /**
+         * Jenkins (un)helpfully wipes out any initialization done in constructors
+         * or class definitions before executing this #perform method. So we need to
+         * initialize it in case it wasn't already.
+         */
+        private void initialize() throws URISyntaxException {
+            if (this.converter == null) {
+                this.converter = new DefaultBuildToOrchestrateAPI(
+                        new DefaultBuildToJSON());
+            }
+
+            if (this.eventqClient == null) {
+                this.eventqClient = new AmqpOrchestrateClient();
+            }
+        }
+
+        /**
+         * Logging helper that prepends the log message prefix
+         *
+         * @param msg
+         * @param printStream
+         */
+        private void log(String msg, PrintStream printStream) {
+            printStream.print(LOG_MESSAGE_PREFIX);
+            printStream.println(msg);
+        }
+
+
+        public StandardUsernamePasswordCredentials getCredentials() {
+            return getCredentials(this.run.getParent(),
+                    this.step.getCredentialsId(), this.step.getServerUrl());
+        }
+        
+        public static StandardUsernamePasswordCredentials getCredentials(Item owner,
+                String credentialsId, String serverUrl) {
+            StandardUsernamePasswordCredentials result = null;
+            if (!isBlank(credentialsId)) {
+                for (StandardUsernamePasswordCredentials c : lookupCredentials(owner, serverUrl)) {
+                    if (c.getId().equals(credentialsId)) {
+                        result = c;
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+
+        public static List<StandardUsernamePasswordCredentials> lookupCredentials(Item owner, String serverUrl) {
+            URIRequirementBuilder rBuilder = isBlank(serverUrl) ?
+                    URIRequirementBuilder.create() : URIRequirementBuilder.fromUri(serverUrl);
+            return CredentialsProvider.lookupCredentials(
+                    StandardUsernamePasswordCredentials.class, owner, null, rBuilder.build());
+        }
+    }
+
+}

--- a/src/main/java/jenkins/plugins/collabnet/steps/SynchNonBlockingStepExecution.java
+++ b/src/main/java/jenkins/plugins/collabnet/steps/SynchNonBlockingStepExecution.java
@@ -1,0 +1,97 @@
+// This is copied from workflow-step-api plugin source code. Once the dependency is updated (2.12),
+// this can be deleted and PublishEventQStep can extend SynchronousNonBlockingStepExecution in the workflow-step-api-plugin 
+package jenkins.plugins.collabnet.steps;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.annotation.Nonnull;
+
+import org.acegisecurity.Authentication;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.security.ACL;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;
+import jenkins.model.Jenkins;
+
+/**
+ * Similar to {@link SynchronousStepExecution} (it executes synchronously too) but it does not block the CPS VM thread.
+ * @see StepExecution
+ * @param <T> the type of the return value (may be {@link Void})
+ */
+public abstract class SynchNonBlockingStepExecution<T> extends StepExecution {
+
+    private transient volatile Future<?> task;
+    private transient String threadName;
+
+    private static ExecutorService executorService;
+
+    protected SynchNonBlockingStepExecution(@Nonnull StepContext context) {
+        super(context);
+    }
+
+    /**
+     * Meat of the execution.
+     *
+     * When this method returns, a step execution is over.
+     */
+    protected abstract T run() throws Exception;
+
+    @Override
+    public final boolean start() throws Exception {
+        final Authentication auth = Jenkins.getAuthentication();
+        task = getExecutorService().submit(new Runnable() {
+            @SuppressFBWarnings(value="SE_BAD_FIELD", justification="not serializing anything here")
+            @Override public void run() {
+                try {
+                    getContext().onSuccess(ACL.impersonate(auth,
+                            new jenkins.security.NotReallyRoleSensitiveCallable<T, Exception>() {
+                        @Override public T call() throws Exception {
+                            threadName = Thread.currentThread().getName();
+                            return SynchNonBlockingStepExecution.this.run();
+                        }
+                    }));
+                } catch (Exception e) {
+                    getContext().onFailure(e);
+                }
+            }
+        });
+        return false;
+    }
+
+    /**
+     * If the computation is going synchronously, try to cancel that.
+     */
+    @Override
+    public void stop(Throwable cause) throws Exception {
+        if (task != null) {
+            task.cancel(true);
+        }
+    }
+
+    @Override
+    public void onResume() {
+        getContext().onFailure(new Exception("Resume after a restart not supported for non-blocking synchronous steps"));
+    }
+
+    @Override public @Nonnull String getStatus() {
+        if (threadName != null) {
+            return "running in thread: " + threadName;
+        } else {
+            return "not yet scheduled";
+        }
+    }
+
+    static synchronized ExecutorService getExecutorService() {
+        if (executorService == null) {
+            executorService = Executors.newCachedThreadPool(new NamingThreadFactory(new DaemonThreadFactory(),
+                    "jenkins.plugins.collabnet.steps.SynchronousNonBlockingStepExecution"));
+        }
+        return executorService;
+    }
+
+}

--- a/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/config.jelly
@@ -1,0 +1,22 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+
+  <f:entry title="Server URL" field="serverUrl">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="${%Credentials}" field="credentialsId">
+    <c:select />
+  </f:entry>
+  <f:entry title="Build source association key" field="sourceKey">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="${%Status}" field="status">
+   <f:select />
+  </f:entry>
+  <f:entry title="Exclude commit info" field="excludeCommitInfo" >
+    <f:checkbox />
+  </f:entry>
+  <f:entry title="Mark Unstable" field="markUnstable" >
+    <f:checkbox default="true" />
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-credentialsId.html
+++ b/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-credentialsId.html
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2017 CollabNet, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div>
+    <p>If none is given, global TeamForge credentials will be used for this job.</p>
+</div>

--- a/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-excludeCommitInfo.html
+++ b/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-excludeCommitInfo.html
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2017 CollabNet, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div>
+    Whether to exclude associated commit information in EventQ notification.
+</div>

--- a/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-markUnstable.html
+++ b/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-markUnstable.html
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2017 CollabNet, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div>
+    Mark current job as <strong>unstable</strong> if this step fails to notify EventQ.
+</div>

--- a/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-serverUrl.html
+++ b/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-serverUrl.html
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright 2017 CollabNet, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div>
+    This is the URL to your TeamForge EventQ message-queue server. It should not have any path information in it. For example:
+    <em>amqp://mq.example.com:5672</em>
+</div>

--- a/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-sourceKey.html
+++ b/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-sourceKey.html
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright 2017 CollabNet, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div>
+    This is the key to the build source on your TeamForge EventQ server. You can find it by visiting the
+    configuration page for the source to which builds should be reported.
+</div>

--- a/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-status.html
+++ b/src/main/resources/jenkins/plugins/collabnet/steps/PublishEventQStep/help-status.html
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2017 CollabNet, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div>
+    (Optional) Specify EventQ status explicitly. If not provided, it will be determined based on the current run result.
+</div>

--- a/src/test/java/hudson/plugins/collabnet/orchestrate/TestDefaultBuildToJSON.java
+++ b/src/test/java/hudson/plugins/collabnet/orchestrate/TestDefaultBuildToJSON.java
@@ -258,7 +258,7 @@ public class TestDefaultBuildToJSON {
     public void resultsMathIsCorrect() throws URISyntaxException {
         // Setup
         AbstractTestResultAction results = mocks.createMock("results", AbstractTestResultAction.class);
-        converter = mocks.createMock("converter", converterBuilder.addMockedMethod("getBuildURI", AbstractBuild.class));
+        converter = mocks.createMock("converter", converterBuilder.addMockedMethod("getBuildURI", Run.class));
 
         expect(converter.getBuildURI(build)).andReturn(serverUri.resolve("/blah/"));
         expect(build.getAction(AbstractTestResultAction.class)).andReturn(results);
@@ -287,7 +287,7 @@ public class TestDefaultBuildToJSON {
     public void testURLIsCorrect() throws URISyntaxException {
         // Setup
         AbstractTestResultAction results = mocks.createMock("results", AbstractTestResultAction.class);
-        converter = mocks.createMock("converter", converterBuilder.addMockedMethod("getBuildURI", AbstractBuild.class));
+        converter = mocks.createMock("converter", converterBuilder.addMockedMethod("getBuildURI", Run.class));
 
         expect(converter.getBuildURI(build)).andReturn(serverUri.resolve("/blah/"));
 
@@ -317,7 +317,7 @@ public class TestDefaultBuildToJSON {
     public void noRevisionsReturnsEmptyArray() throws IOException {
         //Setup
         converter = mocks.createMock("converter",
-                converterBuilder.addMockedMethod("getRepositoryInfo", AbstractBuild.class));
+                converterBuilder.addMockedMethod("getRepositoryInfo", Run.class));
         expect(converter.getRepositoryInfo(build)).andReturn(repositoryInfo);
 
         ChangeLogSet changeLogSet = new FakeChangeLogSet(build);
@@ -342,7 +342,7 @@ public class TestDefaultBuildToJSON {
     public void revisionReturnsCorrectData() throws IOException {
         //Setup
         converter = mocks.createMock("converter",
-                converterBuilder.addMockedMethod("getRepositoryInfo", AbstractBuild.class));
+                converterBuilder.addMockedMethod("getRepositoryInfo", Run.class));
         expect(converter.getRepositoryInfo(build)).andReturn(repositoryInfo);
 
         ChangeLogSet changeLogSet = new FakeChangeLogSet(build, new FakeChangeLogEntry("12345"));
@@ -371,13 +371,14 @@ public class TestDefaultBuildToJSON {
         //Setup
         AbstractBuild build2 = mocks.createMock("build2", AbstractBuild.class);
         converter = mocks.createMock("converter",
-                converterBuilder.addMockedMethod("getRepositoryInfo", AbstractBuild.class));
+                converterBuilder.addMockedMethod("getRepositoryInfo", Run.class));
         expect(converter.getRepositoryInfo(build)).andReturn(repositoryInfo);
 
         ChangeLogSet changeLogSet = new FakeChangeLogSet(build);
         ChangeLogSet changeLogSet2 = new FakeChangeLogSet(build, new FakeChangeLogEntry("252525"));
         expect(build.getChangeSet()).andReturn(changeLogSet).atLeastOnce();
-        expect(build.getPreviousBuild()).andReturn(build2);
+        AbstractBuild previousBuild = build.getPreviousBuild();
+        expect(previousBuild).andReturn(build2);
         expect(build2.getChangeSet()).andReturn(changeLogSet2).atLeastOnce();
 
         mocks.replayAll();

--- a/src/test/java/jenkins/plugins/collabnet/steps/TestPublishEventQStep.java
+++ b/src/test/java/jenkins/plugins/collabnet/steps/TestPublishEventQStep.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 CollabNet, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jenkins.plugins.collabnet.steps;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.model.Result;
+import jenkins.plugins.collabnet.steps.PublishEventQStep;
+
+public class TestPublishEventQStep {
+    
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void buildWithEmptyServerUrlMustFail() throws Exception {
+        WorkflowJob p = jenkins.jenkins.createProject(WorkflowJob.class, "p");
+        
+        p.setDefinition(new CpsFlowDefinition(
+                "publishEventQ serverUrl: '', sourceKey: '1234', markUnstable: true"
+        ));
+        WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        jenkins.assertBuildStatus(Result.UNSTABLE, jenkins.waitForCompletion(b1));
+        jenkins.assertLogContains(PublishEventQStep.PublishEventQStepExecution.LOG_MESSAGE_INVALID_URL, b1);
+    }
+
+    @Test
+    public void buildWithEmptySourceKeyMustFail() throws Exception {
+        WorkflowJob p = jenkins.jenkins.createProject(WorkflowJob.class, "p");
+        
+        p.setDefinition(new CpsFlowDefinition(
+                "publishEventQ serverUrl: 'amqp://mq.example.com:5672', sourceKey: '', markUnstable: true"
+        ));
+        WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        jenkins.assertBuildStatus(Result.UNSTABLE, jenkins.waitForCompletion(b1));
+        jenkins.assertLogContains(PublishEventQStep.PublishEventQStepExecution.LOG_MESSAGE_INVALID_SOURCE_KEY, b1);
+    }
+}


### PR DESCRIPTION
- Added dependencies:
  Credentials plugin (1.22),
  workflow-cps plugin (2.8) (test only)

- Introduce 'publishEventQ' pipeline step. This step will report the
current pipeline job status to TeamForge EventQ server. Expects the
following parameters: 
  1. serverUrl: EventQ URL,
  2. sourceKey: Associated source key,
  3. credentialsId: Single-select, makes use o credentials plugin to
list available credentials. If 'none' is selected, then uses global
TeamForge credentials,
  4. status: (Optional) EventQ status. If null, then the status is
determined based on the current run result.
  5. excludeCommitInfo: (Optional) whether to exclude commit info in
EventQ notification (default is false)
  6. markUnstable: (Optional) When set to true, marks the current Run as
unstable if the step fails to notify EventQ
  
- ActionHubPlugin.java
  Don't try to connect if TeamForgeShare descriptor is null. Fixes the
issue when CollabNet is first installed,

- DefaultBuildToJSON.java
- BuildToJSON.java
- BuildToOrchestrateAPI.java
- DefaultBuildToOrchestrateAPI.java
- TestDefaultBuildToJSON.java
  Refactor to work with Run instance instead of AbstructBuild, Added new
methods to accept user-supplied EventQ status, and 'excludeCommitInfo'
flag.

- DefaultBuildToJSON.java
  Handle the case when run.result is not set (defaults to success)