### PR TITLE
[JENKINS-55892] Correct UserSeed regression

### DIFF
--- a/src/main/java/hudson/plugins/collabnet/auth/CNFilter.java
+++ b/src/main/java/hudson/plugins/collabnet/auth/CNFilter.java
@@ -18,6 +18,7 @@ import hudson.model.Hudson;
 import hudson.plugins.collabnet.util.CommonUtil;
 import hudson.security.SecurityRealm;
 
+import jenkins.security.SecurityListener;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
@@ -132,6 +133,8 @@ public class CNFilter implements Filter {
         // see artf42298
         request.getSession(true);
         SecurityContextHolder.getContext().setAuthentication(auth);
+
+        SecurityListener.fireLoggedIn(auth.getName());
     }
     
     /**


### PR DESCRIPTION
- due to the lack of event trigger

See [JENKINS-55892](https://issues.jenkins-ci.org/browse/JENKINS-55892).

Attached patched HPI: 
[CollabNet-2.0.7-SNAPSHOT.hpi.zip](https://github.com/jenkinsci/collabnet-plugin/files/2827103/CollabNet-2.0.7-SNAPSHOT.hpi.zip) (As zip as GH does not allow `.hpi`)

