### PR TITLE
[artf393131] Add a text field to configure TF webhook url

### DIFF
--- a/src/main/java/hudson/plugins/collabnet/orchestrate/BuildNotifier.java
+++ b/src/main/java/hudson/plugins/collabnet/orchestrate/BuildNotifier.java
@@ -138,10 +138,12 @@ public class BuildNotifier extends Notifier {
                     this.webhookUrl = Helper.getWebhookUrl(this.ctfUrl);
                 }
                 config.setWebhookUrl(this.webhookUrl);
+                this.webhookUsername = config.webhookUsername;
+                this.webhookPassword = config.webhookPassword;
                 this.setSupportWebhook(true);
                 logger.log(Level.INFO,"Webhook endpoint is registered successfully: " + webhookUrl);
             } catch (IOException e) {
-                e.printStackTrace();
+                logger.log(Level.INFO,"TeamForge Associations - " + e.getLocalizedMessage(), e);
             }
         }
     }

--- a/src/main/java/hudson/plugins/collabnet/orchestrate/BuildNotifierDescriptor.java
+++ b/src/main/java/hudson/plugins/collabnet/orchestrate/BuildNotifierDescriptor.java
@@ -155,4 +155,16 @@ public class BuildNotifierDescriptor extends BuildStepDescriptor<Publisher> {
     public static TeamForgeShare.TeamForgeShareDescriptor getTeamForgeShareDescriptor() {
         return TeamForgeShare.getTeamForgeShareDescriptor();
     }
+
+    /**
+     * Validates that the user provided a webhook url.
+     *
+     * @param webhookUrl
+     *            the webhookUrl provided by the user
+     * @return whether or not the validation succeeded
+     */
+    public FormValidation doCheckWebhookUrl(@QueryParameter String webhookUrl) {
+        return FormValidation.validateRequired(webhookUrl);
+    }
+
 }

--- a/src/main/java/jenkins/plugins/collabnet/steps/PublishWebhookStep.java
+++ b/src/main/java/jenkins/plugins/collabnet/steps/PublishWebhookStep.java
@@ -22,7 +22,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.model.Item;
 import hudson.plugins.collabnet.orchestrate.BuildNotifier;
-import hudson.plugins.collabnet.orchestrate.BuildNotifier.OptionalWebhook;
+import hudson.plugins.collabnet.orchestrate.BuildNotifier.RadioConfig;
 import hudson.plugins.collabnet.orchestrate.PushNotification;
 import hudson.plugins.collabnet.share.TeamForgeShare;
 import hudson.plugins.collabnet.util.Helper;
@@ -36,6 +36,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
+import hudson.util.Secret;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -217,8 +218,9 @@ public class PublishWebhookStep extends Step {
                 String username = c == null ? null : c.getUsername();
                 String password = c == null ?
                         null : (c.getPassword() == null ? null : c.getPassword().getPlainText());
-                OptionalWebhook webhook = new OptionalWebhook(webhookUrl, username, password);
-                pushNotification.handle(run, webhook, listener, this.step.status,
+                RadioConfig config = new RadioConfig(null, null, null, null,
+                        webhookUrl, username, Secret.fromString(password), "eventQ");
+                pushNotification.handle(run, config, listener, this.step.status,
                         this.step.excludeCommitInfo);
             } catch (IllegalStateException ise) {
                 markUnstable(consoleLogger,

--- a/src/main/resources/hudson/plugins/collabnet/orchestrate/BuildNotifier/config.jelly
+++ b/src/main/resources/hudson/plugins/collabnet/orchestrate/BuildNotifier/config.jelly
@@ -17,9 +17,11 @@
   </f:optionalBlock>
 
   <f:block>
-      <f:optionalBlock name="webhook" title="Notify TeamForge" checked="${instance.webhookUrl != null}">
+      <f:radioBlock name="config" value="webhook" title="Notify TeamForge" checked="${instance.webhookUrl != null}">
         <f:entry title="WebHook URL" field="webhookUrl">
           <f:textbox id="webhookUrl" />
+        </f:entry>
+        <f:entry title="User credentials are mandatory for Teamforge 19.2 release and earlier" field="note">
         </f:entry>
         <f:entry title="Username" field="webhookUsername">
           <f:textbox />
@@ -27,11 +29,11 @@
         <f:entry title="Password" field="webhookPassword">
           <f:password />
         </f:entry>
-      </f:optionalBlock>
+      </f:radioBlock>
   </f:block>
 
   <f:block>
-    <f:optionalBlock name="eventQ" title="Notify EventQ" checked="${instance.getSupportEventQ()}">
+    <f:radioBlock name="config" value="eventQ" title="Notify EventQ" checked="${instance.getSupportEventQ()}">
       <f:entry title="MQ URI" field="serverUrl">
         <f:textbox id="orchestrate-serverUrl" />
       </f:entry>
@@ -44,6 +46,6 @@
       <f:entry title="Build source association key" field="sourceKey">
         <f:textbox id="orchestrate-sourceKey"/>
       </f:entry>
-    </f:optionalBlock>
+    </f:radioBlock>
   </f:block>
 </j:jelly>

--- a/src/test/java/hudson/plugins/collabnet/orchestrate/TestBuildNotifier.java
+++ b/src/test/java/hudson/plugins/collabnet/orchestrate/TestBuildNotifier.java
@@ -92,9 +92,9 @@ public class TestBuildNotifier {
         ctfUrl = "http://teamforge.test/sf/project";
         ctfUser = "admin";
         ctfPassword = Secret.fromString("password");
-        BuildNotifier.OptionalEventQ optionalEventQ = new BuildNotifier.OptionalEventQ(serverUrl,
-                serverUsername, serverPassword, associationKey);
-        notifier = new BuildNotifier(null, null, optionalEventQ);
+        BuildNotifier.RadioConfig config = new BuildNotifier.RadioConfig(serverUrl,
+                serverUsername, serverPassword, associationKey, null, null, null, "eventQ");
+        notifier = new BuildNotifier(null, config);
         mocks = new MockUtils();
         listener = mocks.createMock("listener", BuildListener.class);
         outStream = new ByteArrayOutputStream(2048);
@@ -176,9 +176,9 @@ public class TestBuildNotifier {
     @Test
     public void performBuildStripsServerAndSourceKeys() throws Exception {
         // set up
-        BuildNotifier.OptionalEventQ optionalEventQ = new BuildNotifier.OptionalEventQ(serverUrl,
-                serverUsername, serverPassword, associationKey);
-        notifier = new BuildNotifier(null, null, optionalEventQ);
+        BuildNotifier.RadioConfig config = new BuildNotifier.RadioConfig(serverUrl,
+                serverUsername, serverPassword, associationKey, null, null, null, "eventQ");
+        notifier = new BuildNotifier(null, config);
         AbstractBuild build = expectSendToServer(serverUrl, associationKey);
 
         // exercise
@@ -195,9 +195,9 @@ public class TestBuildNotifier {
     @Test
     public void performDoesNotTryToContactEmptyServer() throws Exception {
         // set up
-        BuildNotifier.OptionalEventQ optionalEventQ = new BuildNotifier.OptionalEventQ(null,
-                serverUsername, serverPassword, associationKey);
-        notifier = new BuildNotifier(null, null, optionalEventQ);
+        BuildNotifier.RadioConfig config = new BuildNotifier.RadioConfig(null,
+                serverUsername, serverPassword, associationKey, null, null, null, "eventQ");
+        notifier = new BuildNotifier(null, config);
         AbstractBuild build = mocks.createMock("build", AbstractBuild.class);
 
         printer.println("Starting to send build information to TeamForge EventQ...");
@@ -221,9 +221,9 @@ public class TestBuildNotifier {
     @Test
     public void performDoesNotTryToContactServerWithNoSourceKey() throws Exception {
         // set up
-        BuildNotifier.OptionalEventQ optionalEventQ = new BuildNotifier.OptionalEventQ("http://orchestrate.test",
-                serverUsername, serverPassword, "");
-        notifier = new BuildNotifier(null, null, optionalEventQ);
+        BuildNotifier.RadioConfig config = new BuildNotifier.RadioConfig("http://orchestrate.test",
+                serverUsername, serverPassword, "", null, null, null, "eventQ");
+        notifier = new BuildNotifier(null, config);
         AbstractBuild build = mocks.createMock("build", AbstractBuild.class);
         printer.println("Starting to send build information to TeamForge EventQ...");
         printer.println("The source key for TeamForge EventQ build source is missing.");
@@ -247,9 +247,9 @@ public class TestBuildNotifier {
     public void performDoesNotTryToContactServerWithoutJenkinsRootURL() throws Exception {
         // set up
         String sourceKey = "somekey";
-        BuildNotifier.OptionalEventQ optionalEventQ = new BuildNotifier.OptionalEventQ("http://orchestrate.test",
-                serverUsername, serverPassword, sourceKey);
-        notifier = new BuildNotifier(null, null, optionalEventQ);
+        BuildNotifier.RadioConfig config = new BuildNotifier.RadioConfig("http://orchestrate.test",
+                serverUsername, serverPassword, sourceKey, null, null, null, "eventQ");
+        notifier = new BuildNotifier(null, config);
         AbstractBuild build = mocks.createMock("build", AbstractBuild.class);
         BuildToOrchestrateAPI converter = mocks.createMock("converter", BuildToOrchestrateAPI.class);
         notifier.setConverter(converter);
@@ -277,9 +277,9 @@ public class TestBuildNotifier {
     @Test
     public void performUsesAmqpClientClass() throws Exception {
         // set up
-        BuildNotifier.OptionalEventQ optionalEventQ = new BuildNotifier.OptionalEventQ("amqp://mq.example.com:5672",
-                serverUsername, serverPassword, "somekey");
-        notifier = new BuildNotifier(null, null, optionalEventQ);
+        BuildNotifier.RadioConfig config = new BuildNotifier.RadioConfig("amqp://mq.example.com:5672",
+                serverUsername, serverPassword, "somekey", null, null, null, "eventQ");
+        notifier = new BuildNotifier(null, config);
         AbstractBuild build = mocks.createMock("build", AbstractBuild.class);
         BuildToOrchestrateAPI converter = mocks.createMock("converter", BuildToOrchestrateAPI.class);
         notifier.setConverter(converter);
@@ -303,9 +303,9 @@ public class TestBuildNotifier {
     public void performLogsNotifierActivity() throws Exception {
         // set up
 
-        BuildNotifier.OptionalEventQ optionalEventQ = new BuildNotifier.OptionalEventQ("amqp://mq.example.com:5672",
-                serverUsername, serverPassword, "somekey");
-        notifier = new BuildNotifier(null, null, optionalEventQ);
+        BuildNotifier.RadioConfig config = new BuildNotifier.RadioConfig("amqp://mq.example.com:5672",
+                serverUsername, serverPassword, "somekey", null, null, null, "eventQ");
+        notifier = new BuildNotifier(null, config);
         AbstractBuild build = mocks.createMock("build", AbstractBuild.class);
         BuildToOrchestrateAPI converter = mocks.createMock("converter", BuildToOrchestrateAPI.class);
         notifier.setConverter(converter);

--- a/src/test/java/hudson/plugins/collabnet/orchestrate/TestEntryFieldsOnPages.java
+++ b/src/test/java/hudson/plugins/collabnet/orchestrate/TestEntryFieldsOnPages.java
@@ -49,10 +49,11 @@ public class TestEntryFieldsOnPages {
     /** Tests the configuration properties on the global page. */
     @Test
     public void jobConfigurationHasConnectionInfoAndSourceKey() throws Exception {
-        BuildNotifier.OptionalEventQ optionalEventQ = new BuildNotifier.OptionalEventQ("testUrl",
-                "testUsername", Secret.fromString("testPwd"), "sourceKey");
+        BuildNotifier.RadioConfig config = new BuildNotifier.RadioConfig("testUrl",
+                "testUsername", Secret.fromString("testPwd"), "sourceKey",
+                null, null, null, "eventQ");
 
-        BuildNotifier orcPublisher  = new BuildNotifier(null, null, optionalEventQ);
+        BuildNotifier orcPublisher  = new BuildNotifier(null, config);
 
         project.getPublishersList().add(orcPublisher);
 

--- a/src/test/java/hudson/plugins/collabnet/orchestrate/TestPasswordEncryption.java
+++ b/src/test/java/hudson/plugins/collabnet/orchestrate/TestPasswordEncryption.java
@@ -47,9 +47,9 @@ public class TestPasswordEncryption {
         username = "testUsername";
         password = Secret.fromString("testPwd");
         job = jenkinsRule.createFreeStyleProject();
-        BuildNotifier.OptionalEventQ optionalEventQ = new BuildNotifier.OptionalEventQ("amqp://example.com",
-                username, password,"sourceKey");
-        BuildNotifier orcPublisher = new BuildNotifier(null, null,optionalEventQ);
+        BuildNotifier.RadioConfig config = new BuildNotifier.RadioConfig("amqp://example.com",
+                username, password,"sourceKey", null, null, null, "eventQ");
+        BuildNotifier orcPublisher = new BuildNotifier(null, config);
         job.getPublishersList().add(orcPublisher);
 
     }


### PR DESCRIPTION
To support Webr implementation in both the below cases
 1. Authorization token required (CTF 19.2 - earlier releases)
 2. Authorization token not required (CTF 19.3 - later release)

User will be required to input the the webhook url and
user credentials for the CTF 19.2 - earlier releases.
For the recent 19.3 and later releases, it is enough to
input the webhook url alone. A note is given in the
config page to input the details.