### PR TITLE
[artf393131] Add a text field to configure TF webhook url

### DIFF
--- a/src/main/java/hudson/plugins/collabnet/orchestrate/PushNotification.java
+++ b/src/main/java/hudson/plugins/collabnet/orchestrate/PushNotification.java
@@ -25,9 +25,13 @@ public class PushNotification {
         listener.getLogger().println("Send build notification to : " + webhook.getWebhookUrl());
         JSONObject payload = getPayload(build, listener, status, excludeCommitInfo);
         if(verifyBuildMessage(payload)) {
-            token = Helper.getWebhookToken(getWebhookLogin(webhook.getWebhookUrl()), webhook.getWebhookUsername(),
-                    webhook.getWebhookPassword(), listener);
-            if (token != null) {
+            if (webhook.getWebhookUrl().indexOf("/v4/") == -1) {
+                token = Helper.getWebhookToken(getWebhookLogin(webhook.getWebhookUrl()), webhook.getWebhookUsername(),
+                        webhook.getWebhookPassword(), listener);
+                if (token != null) {
+                    response = send(webhook.getWebhookUrl(), token, payload.toString(), listener);
+                }
+            } else {
                 response = send(webhook.getWebhookUrl(), token, payload.toString(), listener);
             }
         }
@@ -80,7 +84,9 @@ public class PushNotification {
             HttpPost httpPost = new HttpPost(webhookUrl);
             StringEntity entity = new StringEntity(buildData);
             httpPost.setEntity(entity);
-            httpPost.setHeader("Authorization", token);
+            if (token != null) {
+                httpPost.setHeader("Authorization", token);
+            }
             httpPost.setHeader("Accept", "application/json");
             httpPost.setHeader("Content-type", "application/json");
             response = client.execute(httpPost);


### PR DESCRIPTION
To support both WEBR V2 and V4 version in jenkins plugin
following changes made.
In WEBR V4 version there is no authorization token
required to push notification from jenkins to CTF.
Therefore 'Authorization' token is not set when webhook
url is of V4 version.