### PR TITLE
[artf418282] CollabNet Security Realm breaks after Jenkins v2.266 update

### DIFF
--- a/src/main/java/hudson/plugins/collabnet/auth/CollabNetSecurityRealm.java
+++ b/src/main/java/hudson/plugins/collabnet/auth/CollabNetSecurityRealm.java
@@ -89,23 +89,6 @@ public class CollabNetSecurityRealm extends SecurityRealm {
     }
 
     /**
-     * Override the default createFilter.  We want to use one that does not
-     * return a 403 on login redirect because that may cause problems when
-     * Jenkins is run behind a proxy.
-     */
-    @Override
-    public Filter createFilter(FilterConfig filterConfig) {
-        Binding binding = new Binding();
-        SecurityComponents sc = this.createSecurityComponents();
-        binding.setVariable("securityComponents", sc);
-        BeanBuilder builder = new BeanBuilder(getClass().getClassLoader());
-        builder.parse(getClass().
-                      getResourceAsStream("CNSecurityFilters.groovy"),binding);
-        WebApplicationContext context = builder.createApplicationContext();
-        return (Filter) context.getBean("filter");
-    }
-
-    /**
      * The CollabNetSecurityRealm Descriptor class.
      */
     @Extension


### PR DESCRIPTION
Issue:
Jenkins plugin broke in Jenkins v2.266 as there is a changes in
Jenkins security.

Fix:
An exception is thrown while configuring Collabnet security realm.
An exception is thrown from the CreateFilter function of CollabnetSecurityRealm.
The default create filter function is used instead of the customized.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
