### PR TITLE
[artf420768] [Jenkins] Collabnet Document Uploader url directing to old document UI

### DIFF
--- a/src/main/java/com/collabnet/ce/webservices/CTFDocumentFolder.java
+++ b/src/main/java/com/collabnet/ce/webservices/CTFDocumentFolder.java
@@ -60,7 +60,7 @@ public class CTFDocumentFolder extends CTFFolder {
     }
 
     public String getURL() {
-        return app.getServerUrl() + "/sf/docman/do/listDocuments/" + getPath();
+        return app.getServerUrl() + "/ctf/documents/home/" + getPath();
     }
 
 


### PR DESCRIPTION
**Issue:**
Document upload url results in invalid page.

**Fix:**
Due to documents component migration to angular, the url
has been changed. Hence reroute the document url from
_'/sf/docman/do/listDocuments/'_ to _'/ctf/documents/home/'_.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
